### PR TITLE
feat(sentry): integração condicionada por SENTRY_DSN + rota /debug-se…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,3 +72,14 @@ from app.rate_limit import RateLimitMiddleware  # type: ignore
 # capacidade=20 req por 10s por IP+rota (ajuste se quiser)
 app.add_middleware(RateLimitMiddleware, capacity=20, refill_time_s=10)
 # =========================================
+
+# === Observabilidade externa (Sentry) ===
+from app.sentry_init import setup_sentry  # type: ignore
+setup_sentry()
+# ========================================
+
+# === Rota de debug do Sentry ===
+@app.get("/debug-sentry")
+def debug_sentry():
+    1 / 0  # força ZeroDivisionError
+# =================================

--- a/backend/app/sentry_init.py
+++ b/backend/app/sentry_init.py
@@ -1,0 +1,17 @@
+import os
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+
+def setup_sentry():
+    dsn = os.getenv("SENTRY_DSN", "").strip()
+    if not dsn:
+        return  # DSN não setado → não inicializa
+
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[FastApiIntegration()],
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES", "0.1")),   # 10% tracing
+        profiles_sample_rate=float(os.getenv("SENTRY_PROFILES", "0.1")), # 10% profiling
+        send_default_pii=False,
+        environment=os.getenv("SENTRY_ENV", "dev"),
+    )


### PR DESCRIPTION
- Sentry SDK integrado (FastAPI) com ativação via SENTRY_DSN
- traces_sample_rate=0.1 e profiles_sample_rate=0.1
- Rota /debug-sentry para validar captura (gera 500)
- No-op quando SENTRY_DSN não está definido
