### PR TITLE
CI: Fail Fast também em push na main

### DIFF
--- a/.github/workflows/fail_fast.yml
+++ b/.github/workflows/fail_fast.yml
@@ -1,6 +1,8 @@
 name: Fail Fast
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
 
 jobs:
   boom:


### PR DESCRIPTION
Adiciona gatilho de push na main para garantir evento workflow_run ao notify_on_failure.