### PR TITLE
CI: Fix YAML do Fail Fast (printf no MSG) + notify inline

### DIFF
--- a/.github/workflows/fail_fast.yml
+++ b/.github/workflows/fail_fast.yml
@@ -30,13 +30,11 @@ jobs:
           if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
             echo "Sem TELEGRAM_* secrets; pulando envio."; exit 0
           fi
-          MSG="❌ Fail Fast falhou em $REPO
-branch=$BRANCH
-run=$RUN_URL"
+          MSG=$(printf '❌ Fail Fast falhou em %s\nbranch=%s\nrun=%s' "$REPO" "$BRANCH" "$RUN_URL")
           HTTP=$(curl -s -o /tmp/tg.txt -w '%{http_code}' \
                  -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
                  -d chat_id="$TELEGRAM_CHAT_ID" \
-                 --data-urlencode text="$MSG") || true
+                 --data-urlencode "text=$MSG") || true
           echo "HTTP=$HTTP"
           tail -c 1000 /tmp/tg.txt || true
           exit 0


### PR DESCRIPTION
Corrige erro de YAML na string multilinha; usa printf com \n. Mantém notify inline para validar Telegram.