### PR TITLE
chore(client): clean production runtime fallbacks and debug logs

### DIFF
--- a/aurea-gold-client/src/app/customer/components/AIChatModal.tsx
+++ b/aurea-gold-client/src/app/customer/components/AIChatModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { withAuth } from "../../../lib/api";
 
 type Props = { open: boolean; onClose: () => void; };
-const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000";
+const API_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 
 export default function AIChatModal({ open, onClose }: Props) {
   const [msg, setMsg] = useState("");
@@ -56,9 +56,6 @@ export default function AIChatModal({ open, onClose }: Props) {
         setExtra({ saldo_atual: data.resumo_pix.saldo_atual, resumo_pix: data.resumo_pix });
       }
 
-      // debug
-      // eslint-disable-next-line no-console
-      console.log("[AUREA IA][status]", r.status, "[payload]", data);
     } catch (e:any) {
       setError(e?.message || String(e));
       setAnswer("Sem resposta.");

--- a/aurea-gold-client/src/app/customer/components/AureaAssistant.tsx
+++ b/aurea-gold-client/src/app/customer/components/AureaAssistant.tsx
@@ -28,7 +28,7 @@ export default function AureaAssistant() {
   const [loading, setLoading] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
   const [resposta, setResposta] = useState<AIResponseData | null>(null);
-  const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000";
+  const API_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 
   async function consultarIA(e: React.FormEvent) {
     e.preventDefault();

--- a/aurea-gold-client/src/app/customer/components/AureaAssistantPanel.tsx
+++ b/aurea-gold-client/src/app/customer/components/AureaAssistantPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { withAuth } from "../../../lib/api";
 
-const API_BASE = (import.meta as any).env?.VITE_API_BASE || "http://127.0.0.1:8000";
+const API_BASE = String((import.meta as any).env?.VITE_API_BASE || "").replace(/\/+$/, "");
 
 type Msg = { role: "user" | "assistant"; text: string };
 export default function AureaAssistantPanel() {

--- a/aurea-gold-client/src/app/customer/components/AureaSummaryCard.tsx
+++ b/aurea-gold-client/src/app/customer/components/AureaSummaryCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-const API = (import.meta as any).env?.VITE_API_BASE || "http://127.0.0.1:8000";
+const API = String((import.meta as any).env?.VITE_API_BASE || "").replace(/\/+$/, "");
 const REFRESH_MS = Number((import.meta as any).env?.VITE_AI_REFRESH_MS ?? 30000); // 30s padrão
 
 type WindowStats = { entradas: number; saidas: number; qtd: number };

--- a/aurea-gold-client/src/app/customer/components/CardsPanel.tsx
+++ b/aurea-gold-client/src/app/customer/components/CardsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-export default function CardsPanel() { console.log("[AUREA] CardsPanel render");
+export default function CardsPanel() {
   const [masked, setMasked] = useState(true);
   const [locked, setLocked] = useState(false);
 

--- a/aurea-gold-client/src/app/customer/components/QuickPixButtons.tsx
+++ b/aurea-gold-client/src/app/customer/components/QuickPixButtons.tsx
@@ -22,11 +22,9 @@ export default function QuickPixButtons() {
 
   function openPix() {
     window.dispatchEvent(new CustomEvent("aurea:open-pix"));
-    console.log("[Aurea] abrir PIX");
   }
   function clearForm() {
     window.dispatchEvent(new CustomEvent("aurea:clear-pix"));
-    console.log("[Aurea] limpar PIX");
   }
 
   return (

--- a/aurea-gold-client/src/app/lib/api.ts
+++ b/aurea-gold-client/src/app/lib/api.ts
@@ -7,10 +7,7 @@
 import { apiGet as coreGet, apiPost as corePost } from "../../lib/api";
 import { getToken } from "../../lib/auth";
 
-// Fallback local (evita API_BASE vazio derrubar calls)
-export const API_BASE: string =
-  (import.meta as any).env?.VITE_API_BASE ||
-  "http://127.0.0.1:8000";
+export const API_BASE: string = String((import.meta as any).env?.VITE_API_BASE || "").replace(/\/+$/, "");
 
 export function toApi(path: string): string {
   if (path.startsWith("http://") || path.startsWith("https://")) return path;

--- a/aurea-gold-client/src/app/lib/base.ts
+++ b/aurea-gold-client/src/app/lib/base.ts
@@ -1,3 +1,1 @@
-export const BASE_API = String(
-  import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000"
-);
+export const BASE_API = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");

--- a/aurea-gold-client/src/app/lib/bootstrap.ts
+++ b/aurea-gold-client/src/app/lib/bootstrap.ts
@@ -6,5 +6,4 @@ if (typeof globalThis !== "undefined") {
     .replace(/^\/+/, "")
     .replace(/\/+$/, "");
   (globalThis as any).BASE_API = cleanBase;
-  console.log("[BOOTSTRAP] BASE_API set to:", cleanBase);
 }

--- a/aurea-gold-client/src/lib/api.ts
+++ b/aurea-gold-client/src/lib/api.ts
@@ -4,12 +4,7 @@ import { getToken } from "./auth";
 // Seguro, simples e com Authorization automático
 // ======================================================
 
-const FALLBACK_API_BASE: string =
-  typeof window !== "undefined"
-    ? `http://${window.location.hostname}:8000`
-    : "http://127.0.0.1:8000";
-
-export const API_BASE: string = String(import.meta.env.VITE_API_BASE || FALLBACK_API_BASE).replace(/\/+$|\s+/g, "");
+export const API_BASE: string = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$|\s+/g, "");
 export const USER_EMAIL = import.meta.env.VITE_USER_EMAIL || "";
 
 export const DEV_TOKEN: string = String(import.meta.env.VITE_DEV_TOKEN || "").trim();

--- a/aurea-gold-client/src/lib/fetch-refresh.ts
+++ b/aurea-gold-client/src/lib/fetch-refresh.ts
@@ -6,8 +6,7 @@
   W.__AUREA_FETCH_REFRESH__ = "v2";
 
   const API_BASE: string =
-    String(((import.meta as any)?.env?.VITE_API_BASE as string) || "").trim() ||
-    "http://127.0.0.1:8000";
+    String(((import.meta as any)?.env?.VITE_API_BASE as string) || "").trim();
 
   const LOGIN_PATH = "/api/v1/auth/login";
   const REFRESH_PATH = "/api/v1/auth/refresh";

--- a/aurea-gold-client/src/pagamentos/api.ts
+++ b/aurea-gold-client/src/pagamentos/api.ts
@@ -1,4 +1,4 @@
-const RAW_BASE = String(import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000").replace(/\/+$/, "");
+const RAW_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 export const API_BASE = RAW_BASE;
 export type PainelReservasPeriodo = "hoje" | "7d" | "30d";
 

--- a/aurea-gold-client/src/services/api.ts
+++ b/aurea-gold-client/src/services/api.ts
@@ -1,7 +1,7 @@
 import { getToken } from "../lib/auth";
 import { apiGet, type PixHistoryResponse} from "../super2/api";
 
-const RAW_BASE = String(import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000").replace(/\/+$/, "");
+const RAW_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 const BASE_URL = `${RAW_BASE}/api/v1`;
 
 function authHeaders(): Record<string, string> {

--- a/aurea-gold-client/src/services/assist.ts
+++ b/aurea-gold-client/src/services/assist.ts
@@ -1,4 +1,4 @@
-const API = String(import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000").replace(/\/+$/, "");
+const API = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 export async function askAssist(msg: string){
   const r = await fetch(`${API}/api/v1/ai/assist`, {
     method:"POST", headers:{ "Content-Type":"application/json" },

--- a/aurea-gold-client/src/services/auth.ts
+++ b/aurea-gold-client/src/services/auth.ts
@@ -1,5 +1,5 @@
 import { saveTokens, getAccessToken, clearTokens } from "../auth/authClient";
-const RAW_BASE = String(import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000").replace(/\/+$/, "");
+const RAW_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 const BASE_URL = `${RAW_BASE}/api/v1`;
 
 export async function loginRequest(username: string, password: string) {

--- a/aurea-gold-client/src/services/summary.ts
+++ b/aurea-gold-client/src/services/summary.ts
@@ -1,4 +1,4 @@
-const API = String(import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000").replace(/\/+$/, "");
+const API = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 export type SummaryTx = {
   id?: number|string;
   tipo?: string;

--- a/aurea-gold-client/src/super2/AureaPixSendModal.tsx
+++ b/aurea-gold-client/src/super2/AureaPixSendModal.tsx
@@ -49,9 +49,7 @@ export default function AureaPixSendModal({
 
     try {
       setLoading(true);
-      console.log("SUPER2 sendPix payload =>", payload);
       const resp = await sendPix(payload as any);
-      console.log("SUPER2 sendPix resp =>", resp);
 
       setSuccess("PIX enviado com sucesso.");
       setDest("");

--- a/aurea-gold-client/src/super2/ChartSuper2.tsx
+++ b/aurea-gold-client/src/super2/ChartSuper2.tsx
@@ -24,8 +24,6 @@ export default function ChartSuper2() {
   const [err, setErr] = useState<string | null>(null);
 
     useEffect(() => {
-    console.log("DEBUG_CHART_SUPER2_IA_HEADLINE_LOG");
-    console.log("CHART SUPER2 MOUNTED");
   }, []);
 
 

--- a/aurea-gold-client/src/super2/PanelSuper2.tsx
+++ b/aurea-gold-client/src/super2/PanelSuper2.tsx
@@ -57,7 +57,6 @@ export default function PanelSuper2() {
     try {
       setErr(null);
       const hist = await fetchPixHistory();
-      console.log("SUPER2 history raw =>", hist);
 
       const arr = Array.isArray((hist as any)?.dias)
         ? ((hist as any).dias as PixHistoryDay[])
@@ -78,7 +77,6 @@ export default function PanelSuper2() {
     setShowHistory(false);
     setErr(null);
     setHistory([]);
-    console.log("Super2: estado local limpo (histórico/erros).");
   }
 
   return (

--- a/aurea-gold-client/src/super2/SuperAureaHome.tsx
+++ b/aurea-gold-client/src/super2/SuperAureaHome.tsx
@@ -13,7 +13,6 @@ type SuperAureaHomeProps = {
 };
 
 function handlePixShortcutFallback(action: PixShortcutAction) {
-  console.log(`[SuperAureaHome] Atalho PIX clicado: ${action}`);
   alert(
     "Atalho em construção. Em breve este botão vai levar direto para o painel correspondente do Aurea Gold. 😉"
   );
@@ -51,7 +50,6 @@ type AureaServiceKey =
   | "config_negocio";
 
 function handleServiceShortcut(service: AureaServiceKey) {
-  console.log(`[SuperAureaHome] Atalho de serviço clicado: ${service}`);
   alert(
     "Funcionalidade em construção.\n\n" +
       "Esta área do Aurea Gold vai ser ligada a fluxos reais (ex.: empréstimos, cartões, investimentos, cofrinhos, etc.).\n" +
@@ -118,7 +116,6 @@ export default function SuperAureaHome({ onPixShortcut }: SuperAureaHomeProps) {
         localStorage.setItem("aurea_refresh_token", rt);
       }
 
-      console.log("✅ Dev login OK. AT len=", at.length, "origin=", location.origin);
       location.reload();
     } catch (e: any) {
       console.warn("❌ Dev login falhou:", e);
@@ -359,8 +356,7 @@ const saldoDisplay =
 
   // --- PIX Atalhos (wire definitivo) ---
   function handlePixAtalho(action: "send" | "receive" | "extrato") {
-    console.log(`[SuperAureaHome] Atalho PIX clicado: ${action}`);
-
+  
     const tok = getToken();
     if (!tok) {
       setNeedAuth(true);

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -1,10 +1,8 @@
 import { authFetch } from "../auth/authClient";
-const DEFAULT_API_BASE = "http://127.0.0.1:8000";
-export const API_BASE = String(import.meta.env.VITE_API_BASE || DEFAULT_API_BASE).replace(/\/+$/, "");
+export const API_BASE = String(import.meta.env.VITE_API_BASE || "").replace(/\/+$/, "");
 
 
 export const USER_EMAIL: string = String((import.meta as any).env?.VITE_USER_EMAIL || "");
-console.log("SUPER2 API_BASE =>", API_BASE);
 
 // Dia agregado (gráfico + resumos)
 export type PixDayPoint = {


### PR DESCRIPTION
## Resumo
- remove fallbacks de runtime para localhost no client de produção
- centraliza uso de `VITE_API_BASE` sem inventar base local no fluxo principal
- remove logs de debug do produto real sem mexer em arquivos `dev/*` e LAB
- mantém o auth principal intacto

## Validação
- `npm --prefix aurea-gold-client run build` ✅
- `pix_ui_guard.sh` ✅
- varredura do produto real sem `127.0.0.1`/`window.location.hostname` no fluxo principal ✅

## Observações
- restos de DEV/LAB foram preservados de propósito em `src/dev/*`, `index.html`, `.head` e arquivos LAB
- correção pontual em `CardsPanel.tsx` após quebra mecânica do patch ✅