### PR TITLE
fix(pix): avoid local JSONResponse shadowing in history route

### DIFF
--- a/backend/app/api/v1/routes/pix.py
+++ b/backend/app/api/v1/routes/pix.py
@@ -128,7 +128,6 @@ def get_history(
             for t in txs
         ]
 
-        from fastapi.responses import JSONResponse  # garante import local se faltar
 
         return JSONResponse(
             content=jsonable_encoder(result, custom_encoder={Decimal: float})


### PR DESCRIPTION
## Resumo
- remove import local de JSONResponse dentro de get_history
- evita UnboundLocalError no fallback da rota /api/v1/pix/history

## Validação local
- login: 200
- refresh: 200
- pix/balance: 200
- pix/history: 200
- pix/send: 200

## Observações
- os ajustes no SQLite local foram apenas self-heal de ambiente para QA
- nenhuma mudança de banco local entra neste PR