### PR TITLE
feat(wallet): add structured balance contract

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, type WalletAccountStatus } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, type WalletAccountStatus, type WalletStructuredBalance } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -21,6 +21,9 @@ export default function AureaMaisPanel() {
   const [walletStatus, setWalletStatus] = useState<WalletAccountStatus | null>(null);
   const [walletStatusLoading, setWalletStatusLoading] = useState(true);
   const [walletStatusError, setWalletStatusError] = useState<string | null>(null);
+  const [structuredBalance, setStructuredBalance] = useState<WalletStructuredBalance | null>(null);
+  const [structuredBalanceLoading, setStructuredBalanceLoading] = useState(true);
+  const [structuredBalanceError, setStructuredBalanceError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -38,6 +41,21 @@ export default function AureaMaisPanel() {
       .finally(() => {
         if (!alive) return;
         setWalletStatusLoading(false);
+      });
+
+    fetchWalletStructuredBalance()
+      .then((data) => {
+        if (!alive) return;
+        setStructuredBalance(data);
+        setStructuredBalanceError(null);
+      })
+      .catch((error) => {
+        if (!alive) return;
+        setStructuredBalanceError(error instanceof Error ? error.message : "Falha ao carregar saldo estruturado.");
+      })
+      .finally(() => {
+        if (!alive) return;
+        setStructuredBalanceLoading(false);
       });
 
     return () => {
@@ -67,6 +85,18 @@ export default function AureaMaisPanel() {
       : wallet?.account_status === "partner_ready"
       ? "Parceiro pronto"
       : wallet?.account_status || "Não informado";
+  const structuredWallet = structuredBalance?.wallet;
+  const structuredProviderLabel =
+    structuredWallet?.provider === "demo" ? "Demo" : structuredWallet?.provider || "Não configurado";
+  const structuredSourceLabel =
+    structuredWallet?.source === "demo"
+      ? "Demo"
+      : structuredWallet?.source === "partner"
+      ? "Parceiro"
+      : structuredWallet?.source || "Não informado";
+  const structuredRealMoneyLabel = structuredWallet?.real_money_enabled
+    ? "Dinheiro real ativo"
+    : "Dinheiro real desativado";
 
   return (
     <section className="w-full max-w-[960px] mx-auto space-y-5 md:space-y-6">
@@ -164,6 +194,80 @@ export default function AureaMaisPanel() {
               <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
                 {walletStatus.next_steps?.[0] || "Selecionar parceiro financeiro/PSP/BaaS."}
               </p>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          Saldo estruturado
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Contrato de saldo da wallet
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Separação técnica entre saldo disponível, bloqueado e pendente. No modo demo, esses valores não representam dinheiro real.
+            </p>
+          </div>
+
+          <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] ${
+            structuredWallet?.real_money_enabled
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              : "border-amber-500/20 bg-amber-500/10 text-amber-200"
+          }`}>
+            {structuredRealMoneyLabel}
+          </span>
+        </div>
+
+        {structuredBalanceLoading && (
+          <p className="mt-4 text-sm text-[#B8AD95]">
+            Carregando saldo estruturado...
+          </p>
+        )}
+
+        {structuredBalanceError && (
+          <p className="mt-4 text-sm text-rose-300">
+            Não foi possível carregar o saldo estruturado agora.
+          </p>
+        )}
+
+        {structuredBalance && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Disponível</div>
+                <div className="mt-1 text-lg font-semibold text-[#f4f8ff]">R$ {structuredBalance.balance.available.replace(".", ",")}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Bloqueado</div>
+                <div className="mt-1 text-lg font-semibold text-[#f4f8ff]">R$ {structuredBalance.balance.blocked.replace(".", ",")}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Pendente</div>
+                <div className="mt-1 text-lg font-semibold text-[#f4f8ff]">R$ {structuredBalance.balance.pending.replace(".", ",")}</div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Origem</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  {structuredSourceLabel} • Provedor {structuredProviderLabel}
+                </p>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  {structuredBalance.notice}
+                </p>
+              </div>
             </div>
           </>
         )}

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -113,6 +113,30 @@ export function fetchWalletAccountStatus(): Promise<WalletAccountStatus> {
   return apiGet<WalletAccountStatus>("/api/v1/wallet/account-status");
 }
 
+export type WalletStructuredBalance = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  balance: {
+    available: string;
+    blocked: string;
+    pending: string;
+    currency: string;
+  };
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    real_money_enabled: boolean;
+    adapter_error?: string | null;
+  };
+  notice: string;
+};
+
+export function fetchWalletStructuredBalance(): Promise<WalletStructuredBalance> {
+  return apiGet<WalletStructuredBalance>("/api/v1/wallet/structured-balance");
+}
+
 // 🔹 usado pelo painel Super2 (gráfico + saldos)
 export function fetchPixBalance(): Promise<PixBalancePayload> {
   return apiGet<PixBalancePayload>("/api/v1/pix/balance?days=7");

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -8,6 +8,7 @@ from app.models.transaction import Transaction
 from app.models.user_main import User
 from app.config import WALLET_MODE, IS_PARTNER_WALLET
 from app.partner import get_partner_adapter
+from app.services.wallet_partner_service import get_wallet_balance as get_partner_wallet_balance
 
 router = APIRouter()
 
@@ -109,6 +110,64 @@ def get_wallet_account_status(
     e próximos passos de ativação.
     """
     return _account_status_payload(current_user)
+
+
+def _decimal_as_money(value) -> str:
+    return f"{Decimal(value or 0):.2f}"
+
+
+@router.get("/api/v1/wallet/structured-balance")
+def get_wallet_structured_balance(
+    current_user: User = Depends(require_customer),
+):
+    """
+    Saldo estruturado da wallet.
+
+    Prepara o contrato real da carteira:
+    - available: disponível
+    - blocked: bloqueado
+    - pending: pendente/processando
+    - currency: moeda
+    - provider/source/mode: origem do saldo
+
+    Em modo demo, não representa dinheiro real.
+    """
+    try:
+        balance = get_partner_wallet_balance(user_id=current_user.id)
+        provider = balance.provider
+        mode = balance.mode
+        source = "partner" if IS_PARTNER_WALLET else "demo"
+        adapter_error = None
+    except Exception as exc:
+        balance = None
+        provider = "not_configured"
+        mode = WALLET_MODE
+        source = "unavailable"
+        adapter_error = str(exc)
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "balance": {
+            "available": _decimal_as_money(getattr(balance, "available", Decimal("0.00"))),
+            "blocked": _decimal_as_money(getattr(balance, "blocked", Decimal("0.00"))),
+            "pending": _decimal_as_money(getattr(balance, "pending", Decimal("0.00"))),
+            "currency": getattr(balance, "currency", "BRL") if balance else "BRL",
+        },
+        "wallet": {
+            "mode": mode,
+            "provider": provider,
+            "source": source,
+            "real_money_enabled": bool(IS_PARTNER_WALLET and balance is not None),
+            "adapter_error": adapter_error,
+        },
+        "notice": (
+            "Modo demonstração: saldo não representa dinheiro real."
+            if not IS_PARTNER_WALLET
+            else "Saldo obtido via parceiro financeiro configurado."
+        ),
+    }
 
 
 @router.get("/api/v1/wallet/balance")

--- a/backend/app/partner/types.py
+++ b/backend/app/partner/types.py
@@ -20,6 +20,8 @@ PartnerTransactionStatus = Literal[
 class PartnerBalance:
     user_id: int
     available: Decimal
+    blocked: Decimal = Decimal("0.00")
+    pending: Decimal = Decimal("0.00")
     currency: str = "BRL"
     provider: str = "demo"
     mode: WalletMode = "demo"


### PR DESCRIPTION
## Resumo
- adiciona contrato backend de saldo estruturado da wallet
- expõe /api/v1/wallet/structured-balance
- inclui available, blocked, pending, currency, provider, source e real_money_enabled
- exibe saldo estruturado na aba Mais
- mantém modo demo explícito, sem representar dinheiro real

## Validações
- python3 -m py_compile nos arquivos backend
- rota apareceu no OpenAPI
- endpoint autenticado respondeu em modo demo
- npm run build passou
- PIX UI guard OK