### PR TITLE
feat(wallet): add structured statement contract

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, fetchWalletStructuredBalance, type WalletAccountStatus, type WalletStructuredBalance } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -24,6 +24,9 @@ export default function AureaMaisPanel() {
   const [structuredBalance, setStructuredBalance] = useState<WalletStructuredBalance | null>(null);
   const [structuredBalanceLoading, setStructuredBalanceLoading] = useState(true);
   const [structuredBalanceError, setStructuredBalanceError] = useState<string | null>(null);
+  const [structuredStatement, setStructuredStatement] = useState<WalletStructuredStatement | null>(null);
+  const [structuredStatementLoading, setStructuredStatementLoading] = useState(true);
+  const [structuredStatementError, setStructuredStatementError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -56,6 +59,21 @@ export default function AureaMaisPanel() {
       .finally(() => {
         if (!alive) return;
         setStructuredBalanceLoading(false);
+      });
+
+    fetchWalletStructuredStatement(20)
+      .then((data) => {
+        if (!alive) return;
+        setStructuredStatement(data);
+        setStructuredStatementError(null);
+      })
+      .catch((error) => {
+        if (!alive) return;
+        setStructuredStatementError(error instanceof Error ? error.message : "Falha ao carregar extrato estruturado.");
+      })
+      .finally(() => {
+        if (!alive) return;
+        setStructuredStatementLoading(false);
       });
 
     return () => {
@@ -95,6 +113,18 @@ export default function AureaMaisPanel() {
       ? "Parceiro"
       : structuredWallet?.source || "Não informado";
   const structuredRealMoneyLabel = structuredWallet?.real_money_enabled
+    ? "Dinheiro real ativo"
+    : "Dinheiro real desativado";
+  const statementWallet = structuredStatement?.wallet;
+  const statementProviderLabel =
+    statementWallet?.provider === "demo" ? "Demo" : statementWallet?.provider || "Não configurado";
+  const statementSourceLabel =
+    statementWallet?.source === "demo"
+      ? "Demo"
+      : statementWallet?.source === "partner"
+      ? "Parceiro"
+      : statementWallet?.source || "Não informado";
+  const statementRealMoneyLabel = statementWallet?.real_money_enabled
     ? "Dinheiro real ativo"
     : "Dinheiro real desativado";
 
@@ -268,6 +298,102 @@ export default function AureaMaisPanel() {
                   {structuredBalance.notice}
                 </p>
               </div>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          Extrato estruturado
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Contrato de transações da wallet
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Base para comprovantes, reconciliação e Pix via parceiro. No modo demo, a lista não representa movimentação financeira real.
+            </p>
+          </div>
+
+          <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] ${
+            statementWallet?.real_money_enabled
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              : "border-amber-500/20 bg-amber-500/10 text-amber-200"
+          }`}>
+            {statementRealMoneyLabel}
+          </span>
+        </div>
+
+        {structuredStatementLoading && (
+          <p className="mt-4 text-sm text-[#B8AD95]">
+            Carregando extrato estruturado...
+          </p>
+        )}
+
+        {structuredStatementError && (
+          <p className="mt-4 text-sm text-rose-300">
+            Não foi possível carregar o extrato estruturado agora.
+          </p>
+        )}
+
+        {structuredStatement && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Transações</div>
+                <div className="mt-1 text-lg font-semibold text-[#f4f8ff]">{structuredStatement.statement.count}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Origem</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{statementSourceLabel}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Provedor</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{statementProviderLabel}</div>
+              </div>
+            </div>
+
+            {structuredStatement.statement.items.length > 0 ? (
+              <div className="mt-4 space-y-2">
+                {structuredStatement.statement.items.slice(0, 3).map((item) => (
+                  <div
+                    key={`${item.provider_reference}-${item.amount}-${item.status}`}
+                    className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3"
+                    style={{ padding: "14px 16px" }}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-semibold text-[#f4f8ff]">{item.description}</div>
+                        <div className="mt-1 text-[11px] text-[#B8AD95]">
+                          {item.direction} • {item.status} • {item.provider_reference}
+                        </div>
+                      </div>
+                      <div className="text-sm font-bold text-[#f4f8ff]">
+                        R$ {item.amount.replace(".", ",")}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-4 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Sem transações reais</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  O extrato estruturado está pronto, mas o modo demo ainda não possui movimentações reais via parceiro.
+                </p>
+              </div>
+            )}
+
+            <div className="mt-3 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
+              <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                {structuredStatement.notice}
+              </p>
             </div>
           </>
         )}

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -137,6 +137,41 @@ export function fetchWalletStructuredBalance(): Promise<WalletStructuredBalance>
   return apiGet<WalletStructuredBalance>("/api/v1/wallet/structured-balance");
 }
 
+export type WalletStructuredStatementItem = {
+  provider_reference: string;
+  direction: "credit" | "debit" | string;
+  amount: string;
+  status: string;
+  description: string;
+  created_at?: string | null;
+  source: string;
+  real_money_enabled: boolean;
+};
+
+export type WalletStructuredStatement = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  statement: {
+    items: WalletStructuredStatementItem[];
+    count: number;
+    limit: number;
+    currency: string;
+  };
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    real_money_enabled: boolean;
+    adapter_error?: string | null;
+  };
+  notice: string;
+};
+
+export function fetchWalletStructuredStatement(limit = 20): Promise<WalletStructuredStatement> {
+  return apiGet<WalletStructuredStatement>(`/api/v1/wallet/structured-statement?limit=${encodeURIComponent(String(limit))}`);
+}
+
 // 🔹 usado pelo painel Super2 (gráfico + saldos)
 export function fetchPixBalance(): Promise<PixBalancePayload> {
   return apiGet<PixBalancePayload>("/api/v1/pix/balance?days=7");

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -8,7 +8,10 @@ from app.models.transaction import Transaction
 from app.models.user_main import User
 from app.config import WALLET_MODE, IS_PARTNER_WALLET
 from app.partner import get_partner_adapter
-from app.services.wallet_partner_service import get_wallet_balance as get_partner_wallet_balance
+from app.services.wallet_partner_service import (
+    get_wallet_balance as get_partner_wallet_balance,
+    get_wallet_statement as get_partner_wallet_statement,
+)
 
 router = APIRouter()
 
@@ -166,6 +169,109 @@ def get_wallet_structured_balance(
             "Modo demonstração: saldo não representa dinheiro real."
             if not IS_PARTNER_WALLET
             else "Saldo obtido via parceiro financeiro configurado."
+        ),
+    }
+
+
+def _statement_item_payload(item, *, source: str, real_money_enabled: bool) -> dict:
+    raw = getattr(item, "raw", {}) or {}
+    provider_reference = (
+        getattr(item, "provider_reference", None)
+        or raw.get("provider_reference")
+        or raw.get("id")
+        or "not_available"
+    )
+
+    created_at = (
+        getattr(item, "created_at", None)
+        or raw.get("created_at")
+        or raw.get("timestamp")
+        or raw.get("date")
+    )
+
+    return {
+        "provider_reference": str(provider_reference),
+        "direction": getattr(item, "direction", "credit"),
+        "amount": _decimal_as_money(getattr(item, "amount", Decimal("0.00"))),
+        "status": getattr(item, "status", "pending"),
+        "description": getattr(item, "description", None) or "PIX",
+        "created_at": created_at,
+        "source": source,
+        "real_money_enabled": real_money_enabled,
+    }
+
+
+@router.get("/api/v1/wallet/structured-statement")
+def get_wallet_structured_statement(
+    limit: int = 50,
+    current_user: User = Depends(require_customer),
+):
+    """
+    Extrato estruturado da wallet.
+
+    Prepara o contrato real de transações:
+    - provider_reference
+    - direction: credit/debit
+    - amount
+    - status
+    - description
+    - created_at
+    - source
+    - real_money_enabled
+
+    Em modo demo, pode retornar lista vazia e nunca representa dinheiro real.
+    """
+    safe_limit = max(1, min(int(limit or 50), 100))
+
+    try:
+        adapter = get_partner_adapter()
+        provider = adapter.provider_name
+        statement = get_partner_wallet_statement(
+            user_id=current_user.id,
+            limit=safe_limit,
+        )
+        mode = WALLET_MODE
+        source = "partner" if IS_PARTNER_WALLET else "demo"
+        real_money_enabled = bool(IS_PARTNER_WALLET)
+        adapter_error = None
+    except Exception as exc:
+        provider = "not_configured"
+        statement = []
+        mode = WALLET_MODE
+        source = "unavailable"
+        real_money_enabled = False
+        adapter_error = str(exc)
+
+    items = [
+        _statement_item_payload(
+            item,
+            source=source,
+            real_money_enabled=real_money_enabled,
+        )
+        for item in statement
+    ]
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "statement": {
+            "items": items,
+            "count": len(items),
+            "limit": safe_limit,
+            "currency": "BRL",
+        },
+        "wallet": {
+            "mode": mode,
+            "provider": provider,
+            "source": source,
+            "real_money_enabled": real_money_enabled,
+            "adapter_error": adapter_error,
+        },
+        "notice": (
+            "Modo demonstração: extrato não representa movimentação financeira real."
+            if not IS_PARTNER_WALLET
+            else "Extrato obtido via parceiro financeiro configurado."
         ),
     }
 

--- a/backend/app/partner/types.py
+++ b/backend/app/partner/types.py
@@ -76,6 +76,7 @@ class StatementItem:
     direction: Literal["credit", "debit"]
     status: PartnerTransactionStatus
     description: str = "PIX"
+    created_at: str | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
 


### PR DESCRIPTION
## Resumo
- adiciona contrato backend de extrato estruturado da wallet
- expõe /api/v1/wallet/structured-statement
- inclui provider_reference, direction, amount, status, description, created_at, source e real_money_enabled
- exibe Extrato estruturado na aba Mais
- mantém modo demo explícito, sem representar movimentação financeira real

## Validações
- python3 -m py_compile nos arquivos backend
- rota apareceu no OpenAPI
- endpoint autenticado respondeu em modo demo
- npm run build passou
- PIX UI guard OK