### PR TITLE
feat(wallet): add receipt reconciliation foundation

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -27,6 +27,9 @@ export default function AureaMaisPanel() {
   const [structuredStatement, setStructuredStatement] = useState<WalletStructuredStatement | null>(null);
   const [structuredStatementLoading, setStructuredStatementLoading] = useState(true);
   const [structuredStatementError, setStructuredStatementError] = useState<string | null>(null);
+  const [receiptReconciliation, setReceiptReconciliation] = useState<WalletReceiptReconciliation | null>(null);
+  const [receiptReconciliationLoading, setReceiptReconciliationLoading] = useState(true);
+  const [receiptReconciliationError, setReceiptReconciliationError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -74,6 +77,21 @@ export default function AureaMaisPanel() {
       .finally(() => {
         if (!alive) return;
         setStructuredStatementLoading(false);
+      });
+
+    fetchWalletReceiptReconciliation("demo-ui-preview")
+      .then((data) => {
+        if (!alive) return;
+        setReceiptReconciliation(data);
+        setReceiptReconciliationError(null);
+      })
+      .catch((error) => {
+        if (!alive) return;
+        setReceiptReconciliationError(error instanceof Error ? error.message : "Falha ao carregar comprovante/reconciliação.");
+      })
+      .finally(() => {
+        if (!alive) return;
+        setReceiptReconciliationLoading(false);
       });
 
     return () => {
@@ -127,6 +145,24 @@ export default function AureaMaisPanel() {
   const statementRealMoneyLabel = statementWallet?.real_money_enabled
     ? "Dinheiro real ativo"
     : "Dinheiro real desativado";
+  const receiptWallet = receiptReconciliation?.wallet;
+  const receiptRealMoneyLabel = receiptWallet?.real_money_enabled
+    ? "Dinheiro real ativo"
+    : "Dinheiro real desativado";
+  const receiptProviderLabel =
+    receiptWallet?.provider === "demo" ? "Demo" : receiptWallet?.provider || "Não configurado";
+  const transactionStatusLabel =
+    receiptReconciliation?.receipt.transaction_status === "demo_only"
+      ? "Somente demonstração"
+      : receiptReconciliation?.receipt.transaction_status || "Não informado";
+  const auditStatusLabel =
+    receiptReconciliation?.receipt.audit_status === "demo_recorded"
+      ? "Auditoria demo registrada"
+      : receiptReconciliation?.receipt.audit_status || "Não informado";
+  const reconciliationStatusLabel =
+    receiptReconciliation?.receipt.reconciliation_status === "not_applicable_demo"
+      ? "Não aplicável em demo"
+      : receiptReconciliation?.receipt.reconciliation_status || "Não informado";
 
   return (
     <section className="w-full max-w-[960px] mx-auto space-y-5 md:space-y-6">
@@ -393,6 +429,87 @@ export default function AureaMaisPanel() {
               <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
               <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
                 {structuredStatement.notice}
+              </p>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          Comprovante e reconciliação
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Fundação de auditoria da wallet
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Base para emitir comprovantes confiáveis somente quando houver transação confirmada via parceiro financeiro.
+            </p>
+          </div>
+
+          <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] ${
+            receiptWallet?.real_money_enabled
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              : "border-amber-500/20 bg-amber-500/10 text-amber-200"
+          }`}>
+            {receiptRealMoneyLabel}
+          </span>
+        </div>
+
+        {receiptReconciliationLoading && (
+          <p className="mt-4 text-sm text-[#B8AD95]">
+            Carregando comprovante e reconciliação...
+          </p>
+        )}
+
+        {receiptReconciliationError && (
+          <p className="mt-4 text-sm text-rose-300">
+            Não foi possível carregar a fundação de comprovante agora.
+          </p>
+        )}
+
+        {receiptReconciliation && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Transação</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{transactionStatusLabel}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Auditoria</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{auditStatusLabel}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Reconciliação</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{reconciliationStatusLabel}</div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Recibo</div>
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#D7D0BE]">
+                  {receiptReconciliation.receipt.receipt_id}
+                </p>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Origem</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  Provedor {receiptProviderLabel} • {receiptReconciliation.wallet.source}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-3 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
+              <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                {receiptReconciliation.notice}
               </p>
             </div>
           </>

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -172,6 +172,36 @@ export function fetchWalletStructuredStatement(limit = 20): Promise<WalletStruct
   return apiGet<WalletStructuredStatement>(`/api/v1/wallet/structured-statement?limit=${encodeURIComponent(String(limit))}`);
 }
 
+export type WalletReceiptReconciliation = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  receipt: {
+    receipt_id: string;
+    provider_reference: string;
+    transaction_status: string;
+    audit_status: string;
+    reconciliation_status: string;
+    issued_at: string;
+    currency: string;
+  };
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    real_money_enabled: boolean;
+    adapter_error?: string | null;
+  };
+  notice: string;
+  next_steps: string[];
+};
+
+export function fetchWalletReceiptReconciliation(providerReference = "demo-ui-preview"): Promise<WalletReceiptReconciliation> {
+  return apiGet<WalletReceiptReconciliation>(
+    `/api/v1/wallet/receipt-reconciliation?provider_reference=${encodeURIComponent(providerReference)}`
+  );
+}
+
 // 🔹 usado pelo painel Super2 (gráfico + saldos)
 export function fetchPixBalance(): Promise<PixBalancePayload> {
   return apiGet<PixBalancePayload>("/api/v1/pix/balance?days=7");

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from decimal import Decimal
+from datetime import datetime, timezone
 
 from app.database import get_db
 from app.utils.authz import require_customer
@@ -273,6 +274,95 @@ def get_wallet_structured_statement(
             if not IS_PARTNER_WALLET
             else "Extrato obtido via parceiro financeiro configurado."
         ),
+    }
+
+
+def _safe_receipt_part(value: str | None) -> str:
+    raw = str(value or "not-provided").strip() or "not-provided"
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in raw)
+    return safe[:80] or "not-provided"
+
+
+@router.get("/api/v1/wallet/receipt-reconciliation")
+def get_wallet_receipt_reconciliation(
+    provider_reference: str | None = None,
+    current_user: User = Depends(require_customer),
+):
+    """
+    Fundação de comprovante, auditoria e reconciliação da wallet.
+
+    Este endpoint NÃO gera comprovante financeiro real.
+    Ele prepara o contrato de rastreabilidade para quando houver:
+    - transação real via parceiro;
+    - provider_reference real;
+    - auditoria;
+    - reconciliação;
+    - emissão de comprovante confiável.
+
+    Em modo demo, retorna status explícito de demonstração.
+    """
+    safe_reference = _safe_receipt_part(provider_reference)
+
+    try:
+        adapter = get_partner_adapter()
+        provider = adapter.provider_name
+        adapter_error = None
+    except Exception as exc:
+        provider = "not_configured"
+        adapter_error = str(exc)
+
+    real_money_enabled = bool(IS_PARTNER_WALLET and adapter_error is None)
+    source = "partner" if real_money_enabled else "demo"
+
+    if real_money_enabled:
+        transaction_status = "provider_pending_lookup"
+        audit_status = "pending"
+        reconciliation_status = "pending"
+        notice = "Fundação de comprovante pronta para consultar transação via parceiro financeiro."
+        next_steps = [
+            "Consultar transação pelo provider_reference no parceiro.",
+            "Validar status financeiro da transação.",
+            "Registrar trilha de auditoria.",
+            "Conciliar valor, status e identificador do provedor.",
+            "Emitir comprovante somente após confirmação do parceiro.",
+        ]
+    else:
+        transaction_status = "demo_only"
+        audit_status = "demo_recorded"
+        reconciliation_status = "not_applicable_demo"
+        notice = "Modo demonstração: comprovante e reconciliação não representam movimentação financeira real."
+        next_steps = [
+            "Conectar adapter sandbox do parceiro financeiro.",
+            "Registrar provider_reference real das transações.",
+            "Implementar consulta de status no parceiro.",
+            "Implementar trilha de auditoria e reconciliação.",
+            "Liberar emissão de comprovante apenas para transações confirmadas.",
+        ]
+
+    receipt_id = f"aurea-{source}-receipt-{getattr(current_user, 'id', 'user')}-{safe_reference}"
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "receipt": {
+            "receipt_id": receipt_id,
+            "provider_reference": provider_reference or "not_provided",
+            "transaction_status": transaction_status,
+            "audit_status": audit_status,
+            "reconciliation_status": reconciliation_status,
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "currency": "BRL",
+        },
+        "wallet": {
+            "mode": WALLET_MODE,
+            "provider": provider,
+            "source": source,
+            "real_money_enabled": real_money_enabled,
+            "adapter_error": adapter_error,
+        },
+        "notice": notice,
+        "next_steps": next_steps,
     }
 
 


### PR DESCRIPTION
## Resumo
- adiciona fundação backend de comprovante, auditoria e reconciliação da wallet
- expõe /api/v1/wallet/receipt-reconciliation
- inclui receipt_id, provider_reference, transaction_status, audit_status, reconciliation_status, issued_at, source e real_money_enabled
- exibe card Comprovante e reconciliação na aba Mais
- mantém modo demo explícito, sem gerar comprovante financeiro real

## Validações
- python3 -m py_compile no backend
- rota apareceu no OpenAPI
- endpoint autenticado respondeu em modo demo
- npm run build passou
- PIX UI guard OK