### PR TITLE
feat(wallet): add operational limits foundation

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, fetchWalletOperationalLimits, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation, type WalletOperationalLimits } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -30,6 +30,9 @@ export default function AureaMaisPanel() {
   const [receiptReconciliation, setReceiptReconciliation] = useState<WalletReceiptReconciliation | null>(null);
   const [receiptReconciliationLoading, setReceiptReconciliationLoading] = useState(true);
   const [receiptReconciliationError, setReceiptReconciliationError] = useState<string | null>(null);
+  const [operationalLimits, setOperationalLimits] = useState<WalletOperationalLimits | null>(null);
+  const [operationalLimitsLoading, setOperationalLimitsLoading] = useState(true);
+  const [operationalLimitsError, setOperationalLimitsError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -92,6 +95,21 @@ export default function AureaMaisPanel() {
       .finally(() => {
         if (!alive) return;
         setReceiptReconciliationLoading(false);
+      });
+
+    fetchWalletOperationalLimits()
+      .then((data) => {
+        if (!alive) return;
+        setOperationalLimits(data);
+        setOperationalLimitsError(null);
+      })
+      .catch((error) => {
+        if (!alive) return;
+        setOperationalLimitsError(error instanceof Error ? error.message : "Falha ao carregar limites operacionais.");
+      })
+      .finally(() => {
+        if (!alive) return;
+        setOperationalLimitsLoading(false);
       });
 
     return () => {
@@ -163,6 +181,13 @@ export default function AureaMaisPanel() {
     receiptReconciliation?.receipt.reconciliation_status === "not_applicable_demo"
       ? "Não aplicável em demo"
       : receiptReconciliation?.receipt.reconciliation_status || "Não informado";
+  const operationalWallet = operationalLimits?.wallet;
+  const operationalRealMoneyLabel = operationalWallet?.real_money_enabled
+    ? "Dinheiro real ativo"
+    : "Dinheiro real desativado";
+  const canSendPixLabel = operationalLimits?.permissions.can_send_pix ? "Ativado" : "Desativado";
+  const canReceivePixLabel = operationalLimits?.permissions.can_receive_pix ? "Ativado" : "Desativado";
+  const confirmationLabel = operationalLimits?.permissions.requires_confirmation ? "Obrigatória" : "Não exigida";
 
   return (
     <section className="w-full max-w-[960px] mx-auto space-y-5 md:space-y-6">
@@ -510,6 +535,94 @@ export default function AureaMaisPanel() {
               <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
               <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
                 {receiptReconciliation.notice}
+              </p>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          Limites e segurança operacional
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Controle antes do PIX real
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Base de permissões, limites e confirmação sensível antes de qualquer operação financeira real via parceiro.
+            </p>
+          </div>
+
+          <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] ${
+            operationalWallet?.real_money_enabled
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              : "border-amber-500/20 bg-amber-500/10 text-amber-200"
+          }`}>
+            {operationalRealMoneyLabel}
+          </span>
+        </div>
+
+        {operationalLimitsLoading && (
+          <p className="mt-4 text-sm text-[#B8AD95]">
+            Carregando limites operacionais...
+          </p>
+        )}
+
+        {operationalLimitsError && (
+          <p className="mt-4 text-sm text-rose-300">
+            Não foi possível carregar os limites operacionais agora.
+          </p>
+        )}
+
+        {operationalLimits && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Enviar PIX</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{canSendPixLabel}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Receber PIX</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{canReceivePixLabel}</div>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Confirmação</div>
+                <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{confirmationLabel}</div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Por transação</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  R$ {operationalLimits.limits.per_transaction_limit.replace(".", ",")}
+                </p>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Diário</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  R$ {operationalLimits.limits.daily_limit.replace(".", ",")}
+                </p>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Mensal</div>
+                <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                  R$ {operationalLimits.limits.monthly_limit.replace(".", ",")}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-3 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Motivo</div>
+              <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                {operationalLimits.reason}
               </p>
             </div>
           </>

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -202,6 +202,45 @@ export function fetchWalletReceiptReconciliation(providerReference = "demo-ui-pr
   );
 }
 
+export type WalletOperationalLimits = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    adapter_ready: boolean;
+    adapter_error?: string | null;
+    real_money_enabled: boolean;
+  };
+  permissions: {
+    can_send_pix: boolean;
+    can_receive_pix: boolean;
+    requires_confirmation: boolean;
+  };
+  limits: {
+    per_transaction_limit: string;
+    daily_limit: string;
+    monthly_limit: string;
+    currency: string;
+  };
+  security: {
+    sensitive_action_confirmation_required: boolean;
+    kyc_required: boolean;
+    kyb_required_for_business: boolean;
+    audit_required: boolean;
+    reconciliation_required: boolean;
+  };
+  reason: string;
+  limitations: string[];
+  next_steps: string[];
+};
+
+export function fetchWalletOperationalLimits(): Promise<WalletOperationalLimits> {
+  return apiGet<WalletOperationalLimits>("/api/v1/wallet/operational-limits");
+}
+
 // 🔹 usado pelo painel Super2 (gráfico + saldos)
 export function fetchPixBalance(): Promise<PixBalancePayload> {
   return apiGet<PixBalancePayload>("/api/v1/pix/balance?days=7");

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -366,6 +366,123 @@ def get_wallet_receipt_reconciliation(
     }
 
 
+@router.get("/api/v1/wallet/operational-limits")
+def get_wallet_operational_limits(
+    current_user: User = Depends(require_customer),
+):
+    """
+    Limites e segurança operacional da wallet.
+
+    Este endpoint prepara o contrato de segurança antes de qualquer PIX real:
+    - permissão de envio/recebimento;
+    - limite por transação;
+    - limite diário;
+    - limite mensal;
+    - confirmação obrigatória;
+    - motivo/limitações;
+    - origem e modo da carteira.
+
+    Em modo demo, não permite PIX real.
+    """
+    try:
+        adapter = get_partner_adapter()
+        provider = adapter.provider_name
+        adapter_ready = True
+        adapter_error = None
+    except Exception as exc:
+        provider = "not_configured"
+        adapter_ready = False
+        adapter_error = str(exc)
+
+    real_money_enabled = bool(IS_PARTNER_WALLET and adapter_ready)
+    source = "partner" if real_money_enabled else "demo"
+
+    if real_money_enabled:
+        can_send_pix = True
+        can_receive_pix = True
+        requires_confirmation = True
+        reason = "Carteira em modo parceiro: operações reais dependem dos limites e regras do parceiro financeiro."
+        limitations = [
+            "Limites finais devem ser confirmados pelo PSP/BaaS.",
+            "Toda saída de dinheiro deve exigir confirmação sensível.",
+            "Operações podem ser bloqueadas por KYC/KYB, antifraude ou compliance do parceiro.",
+        ]
+        limits = {
+            "per_transaction_limit": "provider_defined",
+            "daily_limit": "provider_defined",
+            "monthly_limit": "provider_defined",
+            "currency": "BRL",
+        }
+        security = {
+            "sensitive_action_confirmation_required": True,
+            "kyc_required": True,
+            "kyb_required_for_business": True,
+            "audit_required": True,
+            "reconciliation_required": True,
+        }
+        next_steps = [
+            "Buscar limites reais no parceiro financeiro.",
+            "Aplicar confirmação antes de envio de PIX.",
+            "Validar KYC/KYB antes de habilitar operações.",
+            "Registrar auditoria e idempotência para ações sensíveis.",
+        ]
+    else:
+        can_send_pix = False
+        can_receive_pix = False
+        requires_confirmation = True
+        reason = "Modo demonstração: PIX real depende de parceiro financeiro/PSP/BaaS."
+        limitations = [
+            "Envio de PIX real desativado em modo demo.",
+            "Recebimento de PIX real desativado em modo demo.",
+            "Limites financeiros reais ainda dependem de integração com parceiro.",
+            "Confirmação sensível já deve ser prevista antes de qualquer operação real.",
+        ]
+        limits = {
+            "per_transaction_limit": "0.00",
+            "daily_limit": "0.00",
+            "monthly_limit": "0.00",
+            "currency": "BRL",
+        }
+        security = {
+            "sensitive_action_confirmation_required": True,
+            "kyc_required": True,
+            "kyb_required_for_business": True,
+            "audit_required": True,
+            "reconciliation_required": True,
+        }
+        next_steps = [
+            "Selecionar parceiro financeiro/PSP/BaaS.",
+            "Implementar limites sandbox.",
+            "Implementar confirmação antes de envio de dinheiro.",
+            "Conectar limites ao KYC/KYB.",
+            "Bloquear PIX real enquanto real_money_enabled for false.",
+        ]
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "wallet": {
+            "mode": WALLET_MODE,
+            "provider": provider,
+            "source": source,
+            "adapter_ready": adapter_ready,
+            "adapter_error": adapter_error,
+            "real_money_enabled": real_money_enabled,
+        },
+        "permissions": {
+            "can_send_pix": can_send_pix,
+            "can_receive_pix": can_receive_pix,
+            "requires_confirmation": requires_confirmation,
+        },
+        "limits": limits,
+        "security": security,
+        "reason": reason,
+        "limitations": limitations,
+        "next_steps": next_steps,
+    }
+
+
 @router.get("/api/v1/wallet/balance")
 def get_balance(current_user: User = Depends(require_customer),
                 db: Session = Depends(get_db)):


### PR DESCRIPTION
## Resumo
- adiciona endpoint /api/v1/wallet/operational-limits
- estrutura permissões de envio/recebimento PIX
- inclui limites por transação, diário e mensal
- inclui confirmação sensível obrigatória
- exibe card Limites e segurança operacional na aba Mais
- mantém modo demo explícito, sem PIX real antes de parceiro financeiro

## Validações
- python3 -m py_compile no backend
- rota apareceu no OpenAPI
- endpoint autenticado respondeu em modo demo
- npm run build passou
- PIX UI guard OK