### PR TITLE
feat(wallet): add partner sandbox adapter

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,6 +8,15 @@ ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
 # partner = futuro modo com parceiro financeiro/PSP/BaaS
 _wallet_mode_raw = os.getenv("WALLET_MODE", "demo").strip().lower()
 WALLET_MODE = _wallet_mode_raw if _wallet_mode_raw in {"demo", "partner"} else "demo"
+
+_wallet_partner_provider_raw = (
+    os.getenv("WALLET_PARTNER_PROVIDER")
+    or os.getenv("WALLET_PROVIDER")
+    or "demo"
+)
+WALLET_PARTNER_PROVIDER = _wallet_partner_provider_raw.strip().lower()
+IS_SANDBOX_PARTNER = WALLET_PARTNER_PROVIDER in {"sandbox", "partner-sandbox", "sandbox_partner"}
+
 IS_DEMO_WALLET = WALLET_MODE == "demo"
-IS_PARTNER_WALLET = WALLET_MODE == "partner"
+IS_PARTNER_WALLET = WALLET_MODE == "partner" and not IS_SANDBOX_PARTNER
 

--- a/backend/app/partner/__init__.py
+++ b/backend/app/partner/__init__.py
@@ -1,5 +1,6 @@
 from app.partner.base import PartnerAdapter
 from app.partner.demo_adapter import DemoPartnerAdapter
+from app.partner.sandbox_adapter import SandboxPartnerAdapter
 from app.partner.registry import get_partner_adapter
 from app.partner.types import (
     PartnerBalance,
@@ -14,6 +15,7 @@ from app.partner.types import (
 __all__ = [
     "PartnerAdapter",
     "DemoPartnerAdapter",
+    "SandboxPartnerAdapter",
     "get_partner_adapter",
     "PartnerBalance",
     "PartnerWebhookEvent",

--- a/backend/app/partner/registry.py
+++ b/backend/app/partner/registry.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from app.config import WALLET_MODE
+from app.config import IS_SANDBOX_PARTNER, WALLET_MODE, WALLET_PARTNER_PROVIDER
 from app.partner.base import PartnerAdapter
 from app.partner.demo_adapter import DemoPartnerAdapter
+from app.partner.sandbox_adapter import SandboxPartnerAdapter
 
 
 @lru_cache(maxsize=1)
@@ -14,13 +15,18 @@ def get_partner_adapter() -> PartnerAdapter:
 
     Hoje:
     - demo: adapter local, sem dinheiro real.
+    - sandbox: adapter técnico controlado, sem dinheiro real.
 
     Futuro:
-    - partner: adapter real do PSP/BaaS escolhido.
+    - partner: adapter real do PSP/BaaS escolhido e homologado.
     """
+    if IS_SANDBOX_PARTNER:
+        return SandboxPartnerAdapter()
+
     if WALLET_MODE == "demo":
         return DemoPartnerAdapter()
 
     raise RuntimeError(
-        "WALLET_MODE=partner configurado, mas nenhum Partner Adapter real foi registrado."
+        "WALLET_MODE=partner configurado, mas nenhum Partner Adapter real foi registrado "
+        f"para WALLET_PARTNER_PROVIDER={WALLET_PARTNER_PROVIDER!r}."
     )

--- a/backend/app/partner/sandbox_adapter.py
+++ b/backend/app/partner/sandbox_adapter.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.partner.base import PartnerAdapter
+from app.partner.types import (
+    PartnerBalance,
+    PartnerWebhookEvent,
+    PixPaymentRequest,
+    PixPaymentResponse,
+    PixSendRequest,
+    PixSendResponse,
+    StatementItem,
+)
+
+
+class SandboxPartnerAdapter(PartnerAdapter):
+    """
+    Adapter sandbox controlado para simular contrato de PSP/BaaS.
+
+    Regra de segurança:
+    - Não movimenta dinheiro real.
+    - Não confirma envio real de PIX.
+    - Não gera comprovante financeiro real.
+    - Serve apenas para QA, contrato técnico e evolução segura da wallet.
+    """
+
+    provider_name = "sandbox"
+
+    def get_balance(self, *, user_id: int) -> PartnerBalance:
+        return PartnerBalance(
+            user_id=user_id,
+            available=Decimal("0.00"),
+            blocked=Decimal("0.00"),
+            pending=Decimal("0.00"),
+            currency="BRL",
+            provider=self.provider_name,
+            mode="demo",
+            raw={
+                "sandbox": True,
+                "real_money": False,
+                "notice": "sandbox adapter does not represent real funds",
+            },
+        )
+
+    def create_pix_payment(self, request: PixPaymentRequest) -> PixPaymentResponse:
+        return PixPaymentResponse(
+            ok=True,
+            status="pending",
+            amount=request.amount,
+            provider=self.provider_name,
+            provider_reference=request.external_id or f"sandbox-pix-payment-{request.user_id}",
+            qr_code="SANDBOX_QR_CODE_NOT_FOR_REAL_PAYMENT",
+            copy_paste="SANDBOX_COPY_PASTE_NOT_FOR_REAL_PAYMENT",
+            message="PIX sandbox criado para simulação técnica. Não representa cobrança real.",
+            raw={
+                "sandbox": True,
+                "real_money": False,
+                "operation": "create_pix_payment",
+            },
+        )
+
+    def send_pix(self, request: PixSendRequest) -> PixSendResponse:
+        return PixSendResponse(
+            ok=False,
+            status="rejected",
+            amount=request.amount,
+            provider=self.provider_name,
+            provider_reference=request.idempotency_key or f"sandbox-pix-send-blocked-{request.user_id}",
+            message="Envio de PIX bloqueado no sandbox. Não movimenta dinheiro real.",
+            raw={
+                "sandbox": True,
+                "real_money": False,
+                "operation": "send_pix",
+                "blocked_reason": "real_pix_disabled_without_homologated_financial_partner",
+            },
+        )
+
+    def get_statement(self, *, user_id: int, limit: int = 50) -> list[StatementItem]:
+        return []
+
+    def handle_webhook(self, event: PartnerWebhookEvent) -> dict:
+        return {
+            "ok": True,
+            "provider": self.provider_name,
+            "handled": True,
+            "mode": "demo",
+            "sandbox": True,
+            "real_money": False,
+            "event_type": event.event_type,
+            "provider_reference": event.provider_reference,
+            "status": event.status,
+        }


### PR DESCRIPTION
## Resumo
Adiciona adapter sandbox controlado para a camada de parceiro financeiro da wallet Aurea Gold.

## O que foi feito
- Cria SandboxPartnerAdapter
- Adiciona WALLET_PARTNER_PROVIDER para selecionar provider sandbox
- Atualiza registry para resolver demo ou sandbox
- Exporta SandboxPartnerAdapter no módulo partner
- Mantém WALLET_MODE=partner sem adapter real travado por segurança

## Segurança de produto
- Sandbox não movimenta dinheiro real
- Saldo sandbox permanece 0.00
- Cobrança PIX sandbox fica apenas pending/simulada
- Envio PIX sandbox é rejeitado
- real_money_enabled permanece false
- Sem promessa de Pix real, conta real ou operação financeira real antes de parceiro financeiro/PSP/BaaS homologado

## Validações
- py_compile backend
- teste de DemoPartnerAdapter padrão
- teste de SandboxPartnerAdapter com WALLET_MODE=partner WALLET_PARTNER_PROVIDER=sandbox
- validação dos payloads das rotas da wallet em sandbox
- npm run build
- PIX UI guard OK
- git diff --check