### PR TITLE
feat(wallet): add pix sandbox payment foundation

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, fetchWalletOperationalLimits, fetchWalletOnboardingStatus, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation, type WalletOperationalLimits, type WalletOnboardingStatus } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, fetchWalletOperationalLimits, fetchWalletOnboardingStatus, createWalletPixSandboxPayment, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation, type WalletOperationalLimits, type WalletOnboardingStatus, type WalletPixSandboxPayment } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -36,6 +36,9 @@ export default function AureaMaisPanel() {
   const [walletOnboarding, setWalletOnboarding] = useState<WalletOnboardingStatus | null>(null);
   const [walletOnboardingLoading, setWalletOnboardingLoading] = useState(true);
   const [walletOnboardingError, setWalletOnboardingError] = useState<string | null>(null);
+  const [pixSandboxPayment, setPixSandboxPayment] = useState<WalletPixSandboxPayment | null>(null);
+  const [pixSandboxPaymentLoading, setPixSandboxPaymentLoading] = useState(false);
+  const [pixSandboxPaymentError, setPixSandboxPaymentError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -239,6 +242,32 @@ export default function AureaMaisPanel() {
   const onboardingCanOperateLabel = walletOnboarding?.onboarding.can_start_real_operations ? "Liberada" : "Bloqueada";
   const onboardingCanSendPixLabel = walletOnboarding?.onboarding.can_send_pix ? "Ativado" : "Desativado";
   const onboardingCanReceivePixLabel = walletOnboarding?.onboarding.can_receive_pix ? "Ativado" : "Desativado";
+  const pixSandboxPaymentStatusLabel =
+    pixSandboxPayment?.payment.status === "pending"
+      ? "Pendente sandbox"
+      : pixSandboxPayment?.payment.status || "Não gerada";
+
+  async function handleCreatePixSandboxPayment() {
+    setPixSandboxPaymentLoading(true);
+    setPixSandboxPaymentError(null);
+
+    try {
+      const data = await createWalletPixSandboxPayment({
+        amount: "10.00",
+        description: "Cobrança sandbox Aurea Gold",
+        external_id: "aurea-ui-sandbox-payment",
+      });
+      setPixSandboxPayment(data);
+    } catch (error) {
+      setPixSandboxPaymentError(
+        error instanceof Error
+          ? error.message
+          : "Falha ao gerar cobrança PIX sandbox."
+      );
+    } finally {
+      setPixSandboxPaymentLoading(false);
+    }
+  }
 
   return (
     <section className="w-full max-w-[960px] mx-auto space-y-5 md:space-y-6">
@@ -776,6 +805,86 @@ export default function AureaMaisPanel() {
               <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Próximo passo</div>
               <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
                 {walletOnboarding.next_steps?.[0] || "Conectar parceiro financeiro e validar KYC/KYB."}
+              </p>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          PIX sandbox
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Cobrança simulada de entrada
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Gera uma cobrança PIX apenas em sandbox técnico. Não movimenta dinheiro real, não altera saldo e não emite comprovante financeiro real.
+            </p>
+          </div>
+
+          <span className="inline-flex w-fit rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-amber-200">
+            Dinheiro real desativado
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Valor de teste</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">R$ 10,00</div>
+          </div>
+
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Status</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{pixSandboxPaymentStatusLabel}</div>
+          </div>
+
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Saldo real</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">Não altera</div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCreatePixSandboxPayment}
+          disabled={pixSandboxPaymentLoading}
+          className="mt-4 inline-flex w-full items-center justify-center rounded-[18px] border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/15 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+        >
+          {pixSandboxPaymentLoading ? "Gerando sandbox..." : "Gerar cobrança sandbox"}
+        </button>
+
+        {pixSandboxPaymentError && (
+          <p className="mt-3 text-sm leading-relaxed text-rose-300">
+            {pixSandboxPaymentError}
+          </p>
+        )}
+
+        {pixSandboxPayment && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Referência sandbox</div>
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#D7D0BE]">
+                  {pixSandboxPayment.payment.provider_reference}
+                </p>
+              </div>
+
+              <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Copia e cola sandbox</div>
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#D7D0BE]">
+                  {pixSandboxPayment.payment.copy_paste || "Não informado"}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-3 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
+              <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                {pixSandboxPayment.notice}
               </p>
             </div>
           </>

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -273,6 +273,47 @@ export function fetchWalletOnboardingStatus(): Promise<WalletOnboardingStatus> {
   return apiGet<WalletOnboardingStatus>("/api/v1/wallet/onboarding-status");
 }
 
+export type WalletPixSandboxPaymentPayload = {
+  amount: string | number;
+  description?: string;
+  external_id?: string | null;
+};
+
+export type WalletPixSandboxPayment = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  payment: {
+    provider: string;
+    provider_reference: string;
+    status: string;
+    amount: string;
+    currency: string;
+    description: string;
+    qr_code?: string | null;
+    copy_paste?: string | null;
+    created_at: string;
+  };
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    real_money_enabled: boolean;
+  };
+  can_credit_balance: boolean;
+  can_generate_real_receipt: boolean;
+  notice: string;
+  limitations: string[];
+  next_steps: string[];
+};
+
+export function createWalletPixSandboxPayment(
+  payload: WalletPixSandboxPaymentPayload
+): Promise<WalletPixSandboxPayment> {
+  return apiPost<WalletPixSandboxPayment>("/api/v1/wallet/pix/sandbox-payment", payload);
+}
+
+
 
 // 🔹 usado pelo painel Super2 (gráfico + saldos)
 export function fetchPixBalance(): Promise<PixBalancePayload> {

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from decimal import Decimal
 from datetime import datetime, timezone
+from pydantic import BaseModel
 
 from app.database import get_db
 from app.utils.authz import require_customer
@@ -10,6 +11,7 @@ from app.models.user_main import User
 from app.config import WALLET_MODE, IS_PARTNER_WALLET
 from app.partner import get_partner_adapter
 from app.services.wallet_partner_service import (
+    create_wallet_pix_payment as create_partner_pix_payment,
     get_wallet_balance as get_partner_wallet_balance,
     get_wallet_statement as get_partner_wallet_statement,
 )
@@ -620,6 +622,113 @@ def get_wallet_onboarding_status(
     ou receber Pix. Em modo demo, tudo permanece bloqueado.
     """
     return _onboarding_status_payload(current_user)
+
+
+
+
+class WalletPixSandboxPaymentIn(BaseModel):
+    amount: Decimal
+    description: str = "PIX sandbox Aurea Gold"
+    external_id: str | None = None
+
+
+@router.post("/api/v1/wallet/pix/sandbox-payment")
+def create_wallet_pix_sandbox_payment(
+    payload: WalletPixSandboxPaymentIn,
+    current_user: User = Depends(require_customer),
+):
+    """
+    Cria cobrança PIX sandbox de entrada.
+
+    Segurança:
+    - Não movimenta dinheiro real.
+    - Não credita saldo real.
+    - Não gera comprovante financeiro real.
+    - Só funciona quando o adapter ativo for sandbox.
+    """
+    amount = Decimal(payload.amount or Decimal("0.00"))
+
+    if amount <= Decimal("0.00"):
+        raise HTTPException(
+            status_code=422,
+            detail="Valor da cobrança sandbox deve ser maior que zero.",
+        )
+
+    if amount > Decimal("5000.00"):
+        raise HTTPException(
+            status_code=422,
+            detail="Valor da cobrança sandbox excede o limite técnico de simulação.",
+        )
+
+    try:
+        adapter = get_partner_adapter()
+        provider = adapter.provider_name
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Adapter financeiro indisponível para sandbox: {exc}",
+        ) from exc
+
+    if provider != "sandbox":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "PIX sandbox exige WALLET_MODE=partner e "
+                "WALLET_PARTNER_PROVIDER=sandbox. Nenhuma cobrança real foi criada."
+            ),
+        )
+
+    now = datetime.now(timezone.utc)
+    external_id = (
+        _safe_receipt_part(payload.external_id)
+        if payload.external_id
+        else f"sandbox-payment-{getattr(current_user, 'id', 'user')}-{int(now.timestamp())}"
+    )
+
+    payment = create_partner_pix_payment(
+        user_id=getattr(current_user, "id", None),
+        amount=amount,
+        description=payload.description or "PIX sandbox Aurea Gold",
+        external_id=external_id,
+    )
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "payment": {
+            "provider": payment.provider,
+            "provider_reference": payment.provider_reference,
+            "status": payment.status,
+            "amount": _decimal_as_money(payment.amount),
+            "currency": "BRL",
+            "description": payload.description or "PIX sandbox Aurea Gold",
+            "qr_code": payment.qr_code,
+            "copy_paste": payment.copy_paste,
+            "created_at": now.isoformat(),
+        },
+        "wallet": {
+            "mode": WALLET_MODE,
+            "provider": provider,
+            "source": "sandbox",
+            "real_money_enabled": False,
+        },
+        "can_credit_balance": False,
+        "can_generate_real_receipt": False,
+        "notice": "Cobrança PIX sandbox criada apenas para simulação técnica. Não representa pagamento real.",
+        "limitations": [
+            "Não movimenta dinheiro real.",
+            "Não altera saldo real da carteira.",
+            "Não gera comprovante financeiro real.",
+            "Não dispensa homologação com parceiro financeiro/PSP/BaaS.",
+        ],
+        "next_steps": [
+            "Implementar webhook sandbox.",
+            "Validar idempotência da cobrança.",
+            "Simular confirmação sem creditar saldo real.",
+            "Preparar reconciliação sandbox antes de qualquer Pix real.",
+        ],
+    }
 
 
 @router.get("/api/v1/wallet/balance")


### PR DESCRIPTION
## Resumo
Adiciona a fundação de cobrança PIX sandbox de entrada para a wallet Aurea Gold.

## O que foi feito
- Backend: novo endpoint POST /api/v1/wallet/pix/sandbox-payment
- Integração com SandboxPartnerAdapter
- Bloqueio explícito quando o backend está em WALLET_MODE=demo
- Frontend: tipo e fetcher createWalletPixSandboxPayment
- Painel Mais: novo card PIX sandbox com botão Gerar cobrança sandbox

## Segurança de produto
- Não movimenta dinheiro real
- Não altera saldo real
- Não gera comprovante financeiro real
- Não representa pagamento real
- Só funciona com WALLET_MODE=partner e WALLET_PARTNER_PROVIDER=sandbox
- real_money_enabled permanece false
- can_credit_balance permanece false
- can_generate_real_receipt permanece false

## Validações
- py_compile backend
- teste direto do endpoint em sandbox
- teste de bloqueio em demo com HTTP 409
- curl autenticado no endpoint
- npm run build
- PIX UI guard OK
- validação visual do card na aba Mais
- git diff --check