### PR TITLE
feat(wallet): add sandbox audit history

### DIFF
--- a/aurea-gold-client/src/mais/AureaMaisPanel.tsx
+++ b/aurea-gold-client/src/mais/AureaMaisPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, fetchWalletOperationalLimits, fetchWalletOnboardingStatus, createWalletPixSandboxPayment, fetchWalletPixSandboxReconciliation, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation, type WalletOperationalLimits, type WalletOnboardingStatus, type WalletPixSandboxPayment, type WalletPixSandboxReconciliation } from "../super2/api";
+import { fetchWalletAccountStatus, fetchWalletStructuredBalance, fetchWalletStructuredStatement, fetchWalletReceiptReconciliation, fetchWalletOperationalLimits, fetchWalletOnboardingStatus, createWalletPixSandboxPayment, fetchWalletPixSandboxReconciliation, fetchWalletPixSandboxAuditHistory, type WalletAccountStatus, type WalletStructuredBalance, type WalletStructuredStatement, type WalletReceiptReconciliation, type WalletOperationalLimits, type WalletOnboardingStatus, type WalletPixSandboxPayment, type WalletPixSandboxReconciliation, type WalletPixSandboxAuditHistory } from "../super2/api";
 
 const sugestoes = [
   "Recarga de celular",
@@ -43,6 +43,9 @@ export default function AureaMaisPanel() {
   const [sandboxReconciliation, setSandboxReconciliation] = useState<WalletPixSandboxReconciliation | null>(null);
   const [sandboxReconciliationLoading, setSandboxReconciliationLoading] = useState(false);
   const [sandboxReconciliationError, setSandboxReconciliationError] = useState<string | null>(null);
+  const [sandboxAuditHistory, setSandboxAuditHistory] = useState<WalletPixSandboxAuditHistory | null>(null);
+  const [sandboxAuditHistoryLoading, setSandboxAuditHistoryLoading] = useState(false);
+  const [sandboxAuditHistoryError, setSandboxAuditHistoryError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -269,6 +272,13 @@ export default function AureaMaisPanel() {
   const sandboxReconciliationRealMoneyLabel = sandboxReconciliation?.wallet.real_money_enabled
     ? "Dinheiro real ativo"
     : "Dinheiro real desativado";
+  const sandboxAuditHistoryRealMoneyLabel = sandboxAuditHistory?.wallet.real_money_enabled
+    ? "Dinheiro real ativo"
+    : "Dinheiro real desativado";
+  const sandboxAuditHistoryTotalLabel =
+    sandboxAuditHistory?.history.total_returned ?? 0;
+  const sandboxAuditHistoryStatusLabel =
+    sandboxAuditHistoryTotalLabel > 0 ? "Eventos registrados" : "Sem eventos";
 
   async function handleCreatePixSandboxPayment() {
     setPixSandboxPaymentLoading(true);
@@ -307,6 +317,7 @@ export default function AureaMaisPanel() {
     try {
       const data = await fetchWalletPixSandboxReconciliation(reference);
       setSandboxReconciliation(data);
+      void handleFetchSandboxAuditHistory();
     } catch (error) {
       setSandboxReconciliationError(
         error instanceof Error
@@ -315,6 +326,24 @@ export default function AureaMaisPanel() {
       );
     } finally {
       setSandboxReconciliationLoading(false);
+    }
+  }
+
+  async function handleFetchSandboxAuditHistory() {
+    setSandboxAuditHistoryLoading(true);
+    setSandboxAuditHistoryError(null);
+
+    try {
+      const data = await fetchWalletPixSandboxAuditHistory(10);
+      setSandboxAuditHistory(data);
+    } catch (error) {
+      setSandboxAuditHistoryError(
+        error instanceof Error
+          ? error.message
+          : "Falha ao carregar histórico sandbox."
+      );
+    } finally {
+      setSandboxAuditHistoryLoading(false);
     }
   }
 
@@ -1024,6 +1053,105 @@ export default function AureaMaisPanel() {
               <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
               <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
                 {sandboxReconciliation.notice}
+              </p>
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="ag-card rounded-[24px] px-4 py-5 sm:px-5 sm:py-6 border border-amber-500/12 bg-[linear-gradient(180deg,rgba(16,42,55,0.96),rgba(7,15,30,0.98))]">
+        <div className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+          Auditoria sandbox
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#f4f8ff]">
+              Últimos eventos técnicos
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+              Lista os últimos eventos PIX sandbox registrados para auditoria técnica. Não representa movimentação financeira real.
+            </p>
+          </div>
+
+          <span className="inline-flex w-fit rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-amber-200">
+            {sandboxAuditHistoryRealMoneyLabel}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Status</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{sandboxAuditHistoryStatusLabel}</div>
+          </div>
+
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Total exibido</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">{sandboxAuditHistoryTotalLabel}</div>
+          </div>
+
+          <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.74)] px-4 py-3" style={{ padding: "14px 16px", minHeight: "74px" }}>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#B8AD95]">Saldo real</div>
+            <div className="mt-1 text-sm font-semibold text-[#f4f8ff]">Não altera</div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleFetchSandboxAuditHistory}
+          disabled={sandboxAuditHistoryLoading}
+          className="mt-4 inline-flex w-full items-center justify-center rounded-[18px] border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/15 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+        >
+          {sandboxAuditHistoryLoading ? "Carregando..." : "Atualizar histórico sandbox"}
+        </button>
+
+        {sandboxAuditHistoryError && (
+          <p className="mt-3 text-sm leading-relaxed text-rose-300">
+            {sandboxAuditHistoryError}
+          </p>
+        )}
+
+        {sandboxAuditHistory && (
+          <>
+            <div className="mt-4 space-y-3">
+              {sandboxAuditHistory.items.length === 0 ? (
+                <div className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3 text-sm text-[#D7D0BE]" style={{ padding: "14px 16px" }}>
+                  Nenhum evento sandbox registrado ainda.
+                </div>
+              ) : (
+                sandboxAuditHistory.items.slice(0, 5).map((item) => (
+                  <article
+                    key={`${item.provider_reference}-${item.received_at || item.idempotency?.key || item.status}`}
+                    className="rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3"
+                    style={{ padding: "14px 16px" }}
+                  >
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">
+                          {item.status || "unknown"}
+                        </div>
+                        <p className="mt-1 break-words text-sm font-semibold text-[#f4f8ff]">
+                          {item.provider_reference}
+                        </p>
+                      </div>
+
+                      <span className="inline-flex w-fit rounded-full border border-amber-500/16 bg-amber-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-amber-100">
+                        {item.reconciliation_status}
+                      </span>
+                    </div>
+
+                    <p className="mt-2 text-xs leading-relaxed text-[#B8AD95]">
+                      Valor: {item.amount || "não informado"} • Evento: {item.event_type || "não informado"} • Recebido: {item.received_at || "não informado"}
+                    </p>
+                  </article>
+                ))
+              )}
+            </div>
+
+            <div className="mt-3 rounded-[18px] border border-amber-500/10 bg-[rgba(12,30,42,0.56)] px-4 py-3" style={{ padding: "14px 16px" }}>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-[#D4AF37]">Aviso</div>
+              <p className="mt-2 text-sm leading-relaxed text-[#D7D0BE]">
+                {sandboxAuditHistory.notice}
               </p>
             </div>
           </>

--- a/aurea-gold-client/src/super2/api.ts
+++ b/aurea-gold-client/src/super2/api.ts
@@ -357,6 +357,62 @@ export function fetchWalletPixSandboxReconciliation(
   );
 }
 
+export type WalletPixSandboxAuditHistoryItem = {
+  provider: string;
+  provider_reference: string;
+  event_type?: string | null;
+  status: string;
+  amount?: string | null;
+  received_at?: string | null;
+  audit_status: string;
+  reconciliation_status: string;
+  real_money_enabled: boolean;
+  idempotency?: {
+    key: string;
+    request_hash?: string | null;
+    status_code?: number | null;
+    stored_at?: string | null;
+  };
+  can_credit_balance: boolean;
+  can_generate_real_receipt: boolean;
+  can_mark_real_paid: boolean;
+};
+
+export type WalletPixSandboxAuditHistory = {
+  ok: boolean;
+  service: string;
+  user_id?: number | null;
+  history: {
+    provider: string;
+    source: string;
+    limit: number;
+    total_returned: number;
+    audit_status: string;
+  };
+  wallet: {
+    mode: "demo" | "partner" | string;
+    provider: string;
+    source: string;
+    real_money_enabled: boolean;
+  };
+  items: WalletPixSandboxAuditHistoryItem[];
+  can_credit_balance: boolean;
+  can_generate_real_receipt: boolean;
+  can_mark_real_paid: boolean;
+  notice: string;
+  limitations?: string[];
+  next_steps?: string[];
+};
+
+export function fetchWalletPixSandboxAuditHistory(
+  limit = 10
+): Promise<WalletPixSandboxAuditHistory> {
+  return apiGet<WalletPixSandboxAuditHistory>(
+    `/api/v1/wallet/pix/sandbox-audit-history?limit=${encodeURIComponent(String(limit))}`
+  );
+}
+
+
 
 
 

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1116,6 +1116,145 @@ def get_wallet_pix_sandbox_reconciliation(
     }
 
 
+
+
+def _list_sandbox_webhook_events(
+    db: Session,
+    limit: int = 20,
+) -> list[dict]:
+    """
+    Lista eventos sandbox registrados pela idempotência.
+
+    Fase 12: histórico/auditoria sandbox sem nova tabela.
+    Não consulta PSP real, não credita saldo e não emite comprovante real.
+    """
+    safe_limit = max(1, min(int(limit or 20), 100))
+
+    rows = (
+        db.query(IdempotencyKey)
+        .filter(IdempotencyKey.key.like("wallet-sandbox-webhook:%"))
+        .order_by(IdempotencyKey.created_at.desc())
+        .limit(safe_limit)
+        .all()
+    )
+
+    items: list[dict] = []
+
+    for row in rows:
+        raw_response = getattr(row, "response_json", None)
+        if not raw_response:
+            continue
+
+        try:
+            response = json.loads(raw_response)
+        except Exception:
+            continue
+
+        event = response.get("event") or {}
+        wallet_payload = response.get("wallet") or {}
+
+        provider_reference = str(event.get("provider_reference") or "").strip()
+        if not provider_reference:
+            continue
+
+        items.append({
+            "provider": "sandbox",
+            "provider_reference": provider_reference,
+            "event_type": event.get("event_type"),
+            "status": event.get("status") or "unknown",
+            "amount": event.get("amount"),
+            "received_at": event.get("received_at"),
+            "audit_status": "sandbox_event_recorded",
+            "reconciliation_status": "sandbox_reconciled",
+            "real_money_enabled": bool(wallet_payload.get("real_money_enabled", False)),
+            "idempotency": {
+                "key": row.key,
+                "request_hash": row.request_hash,
+                "status_code": row.status_code,
+                "stored_at": row.created_at.isoformat() if row.created_at else None,
+            },
+            "can_credit_balance": False,
+            "can_generate_real_receipt": False,
+            "can_mark_real_paid": False,
+        })
+
+    return items
+
+
+@router.get("/api/v1/wallet/pix/sandbox-audit-history")
+def get_wallet_pix_sandbox_audit_history(
+    limit: int = 20,
+    current_user: User = Depends(require_customer),
+    db: Session = Depends(get_db),
+):
+    """
+    Lista histórico/auditoria de eventos PIX sandbox.
+
+    Segurança:
+    - Não consulta transação real.
+    - Não credita saldo real.
+    - Não gera comprovante financeiro real.
+    - Não marca pagamento real como confirmado.
+    - Usa somente eventos sandbox já registrados por webhook/idempotência.
+    """
+    try:
+        adapter = get_partner_adapter()
+        provider = adapter.provider_name
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Adapter financeiro indisponível para histórico sandbox: {exc}",
+        ) from exc
+
+    if provider != "sandbox":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Histórico sandbox exige WALLET_MODE=partner e "
+                "WALLET_PARTNER_PROVIDER=sandbox. Nenhuma transação real foi consultada."
+            ),
+        )
+
+    safe_limit = max(1, min(int(limit or 20), 100))
+    items = _list_sandbox_webhook_events(db, safe_limit)
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "history": {
+            "provider": "sandbox",
+            "source": "idempotency_keys",
+            "limit": safe_limit,
+            "total_returned": len(items),
+            "audit_status": "sandbox_events_listed",
+        },
+        "wallet": {
+            "mode": WALLET_MODE,
+            "provider": provider,
+            "source": "sandbox",
+            "real_money_enabled": False,
+        },
+        "items": items,
+        "can_credit_balance": False,
+        "can_generate_real_receipt": False,
+        "can_mark_real_paid": False,
+        "notice": "Histórico sandbox listado apenas para auditoria técnica. Não representa movimentação financeira real.",
+        "limitations": [
+            "Não credita saldo real.",
+            "Não confirma pagamento real em parceiro financeiro.",
+            "Não gera comprovante financeiro real.",
+            "Não substitui histórico oficial de PSP/BaaS homologado.",
+        ],
+        "next_steps": [
+            "Exibir últimos eventos sandbox no painel Mais.",
+            "Persistir eventos em tabela própria de auditoria em fase futura.",
+            "Adicionar filtros por status e provider_reference.",
+            "Integrar histórico real somente após parceiro financeiro homologado.",
+        ],
+    }
+
+
 @router.get("/api/v1/wallet/balance")
 def get_balance(current_user: User = Depends(require_customer),
                 db: Session = Depends(get_db)):


### PR DESCRIPTION
## Resumo
Adiciona histórico/auditoria sandbox da wallet Aurea Gold.

## O que foi feito
- Backend: novo endpoint GET /api/v1/wallet/pix/sandbox-audit-history
- Lista eventos sandbox registrados via IdempotencyKey.response_json
- Frontend: novo type WalletPixSandboxAuditHistory
- Frontend: novo fetcher fetchWalletPixSandboxAuditHistory
- Painel Mais: novo card Auditoria sandbox
- Exibe últimos eventos técnicos sandbox com provider_reference, status, valor, tipo de evento e reconciliação

## Segurança de produto
- Não movimenta dinheiro real
- Não altera saldo real
- Não confirma pagamento real
- Não gera comprovante financeiro real
- Não altera PixLedger nem Transaction
- Não substitui histórico oficial de PSP/BaaS homologado
- Mantém aviso explícito de auditoria técnica sandbox

## Validações
- py_compile backend
- SANDBOX_AUDIT_HISTORY_OK
- DEMO_AUDIT_HISTORY_BLOCK_OK
- npm run build
- PIX UI guard OK
- git diff --check
- validação visual do card Auditoria sandbox no painel Mais