### PR TITLE
fix(wallet): align sandbox adapter mode label

### DIFF
--- a/backend/app/partner/sandbox_adapter.py
+++ b/backend/app/partner/sandbox_adapter.py
@@ -35,7 +35,7 @@ class SandboxPartnerAdapter(PartnerAdapter):
             pending=Decimal("0.00"),
             currency="BRL",
             provider=self.provider_name,
-            mode="demo",
+            mode="partner",
             raw={
                 "sandbox": True,
                 "real_money": False,
@@ -84,7 +84,7 @@ class SandboxPartnerAdapter(PartnerAdapter):
             "ok": True,
             "provider": self.provider_name,
             "handled": True,
-            "mode": "demo",
+            "mode": "partner",
             "sandbox": True,
             "real_money": False,
             "event_type": event.event_type,


### PR DESCRIPTION
## Resumo
- Ajusta o label semântico do SandboxPartnerAdapter de mode=demo para mode=partner.
- Mantém provider=sandbox, sandbox=true e real_money=false.
- Não altera fluxo financeiro, saldo, Pix real, idempotência ou reconciliação.

## Validações
- python3 -m py_compile backend/app/partner/sandbox_adapter.py
- git diff --check
- runtime sandbox validado:
  - webhook.mode=partner
  - webhook.sandbox=true
  - webhook.real_money=false
  - wallet.provider=sandbox
  - real_money_enabled=false
  - can_credit_balance=false
  - can_generate_real_receipt=false
  - can_mark_real_paid=false

## Segurança
Este patch é apenas semântico/operacional. Não libera dinheiro real e não altera regras de sandbox.