### PR TITLE
docs(wallet): add partner contact log v1

### DIFF
--- a/docs/WALLET_PARTNER_CONTACT_LOG_V1.md
+++ b/docs/WALLET_PARTNER_CONTACT_LOG_V1.md
@@ -1,0 +1,468 @@
+# Aurea Gold / dils-wallet — Log de Contatos PSP/BaaS v1
+
+## 1. Objetivo
+
+Este documento registra os contatos reais com possíveis parceiros PSP/BaaS da Aurea Gold / dils-wallet.
+
+A Aurea Gold é app real e comercial, com objetivo de Play Store e renda real. Portanto, contato com parceiro financeiro precisa ter rastreabilidade, critério e segurança.
+
+Este log funciona como CRM técnico/comercial simples para controlar:
+
+- parceiro contatado;
+- canal usado;
+- data do contato;
+- resposta recebida;
+- documentos recebidos;
+- riscos identificados;
+- pendências;
+- próxima ação;
+- decisão atual.
+
+---
+
+## 2. Regra permanente
+
+Não avançar para Pix real, dinheiro real, saldo real, liquidação real ou comprovante real sem:
+
+- PSP/BaaS homologado;
+- contrato/parceria formal;
+- KYC/KYB real;
+- compliance;
+- webhook assinado/tokenizado;
+- ledger real separado;
+- reconciliação oficial;
+- plano de incidentes;
+- operação/admin mínima;
+- revisão jurídica, termos de uso e política de privacidade;
+- definição clara de responsabilidade regulatória.
+
+Enquanto isso não existir, a Aurea Gold permanece em demo/sandbox.
+
+---
+
+## 3. Documentos relacionados
+
+Usar como base:
+
+- docs/WALLET_PARTNER_READINESS_MATRIX_V1.md
+- docs/WALLET_PRODUCTION_ENV_CHECKLIST_V1.md
+- docs/WALLET_PSP_BAAS_QUESTIONNAIRE_V1.md
+- docs/WALLET_PARTNER_CONTACT_SCRIPT_V1.md
+- docs/WALLET_PSP_BAAS_SHORTLIST_V1.md
+
+---
+
+## 4. Status possíveis
+
+- not_started: ainda não contatado.
+- contacted: contato inicial enviado.
+- waiting_reply: aguardando resposta.
+- replied: respondeu.
+- meeting_requested: reunião solicitada.
+- meeting_scheduled: reunião agendada.
+- meeting_done: reunião realizada.
+- docs_requested: documentação solicitada.
+- docs_received: documentação recebida.
+- commercial_review: em análise comercial.
+- technical_review: em análise técnica.
+- legal_review: em análise jurídica.
+- approved_candidate: candidato aprovado para próxima fase.
+- paused: pausado.
+- rejected: descartado.
+- no_reply: sem resposta.
+
+---
+
+## 5. Critérios de risco
+
+- low: baixo risco aparente.
+- medium: exige validação.
+- high: risco relevante.
+- blocked: bloqueia avanço.
+
+---
+
+## 6. Primeira rodada recomendada
+
+1. Celcoin
+2. Dock
+3. FitBank
+4. Zoop
+
+Segunda rodada:
+
+5. Stark Bank
+6. Asaas
+7. Efí Bank
+
+Terceira rodada:
+
+8. iugu
+9. Matera
+
+---
+
+## 7. Registro — Celcoin
+
+- Parceiro: Celcoin
+- Categoria: BaaS / Core / Pix
+- Prioridade: A
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://www.celcoin.com.br/
+- Canal usado: pendente
+- Pessoa/área contatada: pendente
+- Data do primeiro contato: pendente
+- Data da última interação: pendente
+- Próxima revisão: pendente
+
+### Mensagem enviada
+
+Pendente.
+
+### Resposta recebida
+
+Pendente.
+
+### Documentos recebidos
+
+Pendente.
+
+### Pontos positivos
+
+- Forte aderência inicial para BaaS, Pix e infraestrutura financeira.
+- Entra na primeira rodada de abordagem.
+- Potencialmente alinhado com wallet/app financeiro.
+
+### Pontos de atenção
+
+- Validar contrato.
+- Validar modelo regulatório.
+- Validar KYC/KYB.
+- Validar ledger/saldo por cliente.
+- Validar webhook assinado.
+- Validar reconciliação oficial.
+- Validar custos e volume mínimo.
+
+### Próxima ação
+
+Enviar mensagem curta usando docs/WALLET_PARTNER_CONTACT_SCRIPT_V1.md.
+
+### Decisão atual
+
+Candidato Prioridade A para primeira abordagem.
+
+---
+
+## 8. Registro — Dock
+
+- Parceiro: Dock
+- Categoria: BaaS / Banking / Pix B2B
+- Prioridade: A
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://dock.tech/
+- Canal usado: pendente
+- Pessoa/área contatada: pendente
+- Data do primeiro contato: pendente
+- Data da última interação: pendente
+- Próxima revisão: pendente
+
+### Mensagem enviada
+
+Pendente.
+
+### Resposta recebida
+
+Pendente.
+
+### Documentos recebidos
+
+Pendente.
+
+### Pontos positivos
+
+- Forte posicionamento em Banking as a Service.
+- Potencial para operação white label.
+- Pode ser parceiro robusto para infraestrutura financeira.
+
+### Pontos de atenção
+
+- Validar se atende produto em estágio inicial.
+- Validar porte mínimo.
+- Validar custos.
+- Validar responsabilidade regulatória.
+- Validar Pix, ledger, KYC/KYB e reconciliação.
+
+### Próxima ação
+
+Enviar abordagem formal usando o roteiro oficial.
+
+### Decisão atual
+
+Candidato Prioridade A para primeira abordagem.
+
+---
+
+## 9. Registro — FitBank
+
+- Parceiro: FitBank
+- Categoria: BaaS / Pix API / White Label
+- Prioridade: A/B
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://dev.fitbank.com.br/
+- Canal usado: pendente
+- Pessoa/área contatada: pendente
+- Data do primeiro contato: pendente
+- Data da última interação: pendente
+- Próxima revisão: pendente
+
+### Mensagem enviada
+
+Pendente.
+
+### Resposta recebida
+
+Pendente.
+
+### Documentos recebidos
+
+Pendente.
+
+### Pontos positivos
+
+- Documentação pública com APIs financeiras.
+- Indícios de Pix, saldo/extrato, onboarding e white label.
+- Boa opção para avaliar tecnicamente.
+
+### Pontos de atenção
+
+- Validar contrato e responsabilidade regulatória.
+- Validar webhook assinado.
+- Validar KYC/KYB.
+- Validar ledger.
+- Validar custos e suporte.
+- Validar ambiente sandbox/homologação.
+
+### Próxima ação
+
+Enviar mensagem curta e pedir reunião técnica.
+
+### Decisão atual
+
+Candidato Prioridade A/B para primeira rodada.
+
+---
+
+## 10. Registro — Zoop
+
+- Parceiro: Zoop
+- Categoria: Banking API / BaaS / Pagamentos
+- Prioridade: A/B
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://www.zoop.com.br/
+- Canal usado: pendente
+- Pessoa/área contatada: pendente
+- Data do primeiro contato: pendente
+- Data da última interação: pendente
+- Próxima revisão: pendente
+
+### Mensagem enviada
+
+Pendente.
+
+### Resposta recebida
+
+Pendente.
+
+### Documentos recebidos
+
+Pendente.
+
+### Pontos positivos
+
+- Potencial aderência para Banking API e BaaS.
+- Pode atender modelo de banco digital com marca do cliente.
+- Entra na primeira rodada ampliada.
+
+### Pontos de atenção
+
+- Validar oferta atual.
+- Validar se atende wallet com saldo.
+- Validar conta por usuário.
+- Validar Pix entrada/saída.
+- Validar KYC/KYB.
+- Validar ledger, webhook e reconciliação.
+
+### Próxima ação
+
+Enviar abordagem inicial após Celcoin/Dock/FitBank ou em paralelo.
+
+### Decisão atual
+
+Candidato Prioridade A/B.
+
+---
+
+## 11. Registro — Stark Bank
+
+- Parceiro: Stark Bank
+- Categoria: Banking API / Pix / Pagamentos corporativos
+- Prioridade: B
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://starkbank.com/
+- Próxima ação: deixar para segunda rodada.
+- Decisão atual: candidato Prioridade B.
+
+---
+
+## 12. Registro — Asaas
+
+- Parceiro: Asaas
+- Categoria: API de pagamentos / Conta digital / Cobranças
+- Prioridade: B
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://www.asaas.com/
+- Próxima ação: avaliar como alternativa de pagamentos/cobranças.
+- Decisão atual: candidato Prioridade B.
+
+---
+
+## 13. Registro — Efí Bank
+
+- Parceiro: Efí Bank
+- Categoria: API Pix / Pagamentos / Cash-in / Cash-out
+- Prioridade: B
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://sejaefi.com.br/
+- Próxima ação: avaliar como alternativa de Pix/pagamentos.
+- Decisão atual: candidato Prioridade B.
+
+---
+
+## 14. Registro — iugu
+
+- Parceiro: iugu
+- Categoria: Cobrança / Pagamentos / Pix / Recorrência
+- Prioridade: B/C
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://www.iugu.com/
+- Próxima ação: considerar em terceira rodada.
+- Decisão atual: candidato Prioridade B/C.
+
+---
+
+## 15. Registro — Matera
+
+- Parceiro: Matera
+- Categoria: Infraestrutura financeira / Core / Pix as a Service
+- Prioridade: C
+- Status: not_started
+- Risco atual: medium
+- Site oficial: https://www.matera.com/br/
+- Próxima ação: deixar em observação estratégica.
+- Decisão atual: candidato Prioridade C.
+
+---
+
+## 16. Registro de reuniões
+
+| Parceiro | Data | Participantes | Canal | Resumo | Próxima ação | Decisão |
+|---|---|---|---|---|---|---|
+| pendente | pendente | pendente | pendente | pendente | pendente | pendente |
+
+---
+
+## 17. Registro de documentos recebidos
+
+| Parceiro | Documento | Tipo | Data recebida | Status | Observação |
+|---|---|---|---|---|---|
+| pendente | pendente | pendente | pendente | pendente | pendente |
+
+---
+
+## 18. Registro de decisões
+
+| Data | Parceiro | Decisão | Motivo | Próxima ação |
+|---|---|---|---|---|
+| pendente | pendente | pendente | pendente | pendente |
+
+---
+
+## 19. Checklist antes de aprovar candidato
+
+Antes de marcar qualquer parceiro como approved_candidate, confirmar:
+
+- contrato formal analisado;
+- responsabilidade regulatória clara;
+- documentação técnica recebida;
+- sandbox oficial liberado;
+- KYC/KYB entendido;
+- Pix entrada entendido;
+- Pix saída entendido;
+- webhook assinado/tokenizado confirmado;
+- idempotência confirmada;
+- ledger/saldo/subcontas confirmados;
+- reconciliação oficial confirmada;
+- custos e tarifas conhecidos;
+- SLA conhecido;
+- suporte conhecido;
+- riscos jurídicos mapeados;
+- decisão humana consciente.
+
+---
+
+## 20. Bloqueios absolutos
+
+Não avançar se:
+
+- parceiro não explica responsabilidade regulatória;
+- parceiro não fornece contrato;
+- parceiro não oferece documentação técnica;
+- parceiro não oferece sandbox;
+- parceiro não possui webhook seguro;
+- parceiro não possui KYC/KYB quando necessário;
+- parceiro não explica custódia;
+- parceiro não permite reconciliação;
+- parceiro promete Pix real sem compliance;
+- parceiro trata dinheiro real como simples endpoint.
+
+Dinheiro real não é feature. É responsabilidade.
+
+---
+
+## 21. Próxima ação operacional
+
+Primeiro contato recomendado:
+
+1. Celcoin
+2. Dock
+3. FitBank
+4. Zoop
+
+Após contato:
+
+1. Atualizar status de cada parceiro.
+2. Registrar mensagem enviada.
+3. Registrar data.
+4. Registrar canal.
+5. Registrar resposta.
+6. Registrar próxima ação.
+7. Não abrir branch técnica até receber documentação real.
+
+---
+
+## 22. Estado deste documento
+
+Versão: v1
+Tipo: log operacional/comercial
+Status: pronto para registrar contatos reais
+Pix real: bloqueado
+Dinheiro real: bloqueado
+Próximo passo: registrar primeiro contato com parceiro Prioridade A


### PR DESCRIPTION
## Resumo

Adiciona o log operacional/comercial de contatos com possíveis parceiros PSP/BaaS da Aurea Gold / dils-wallet.

Arquivo criado:

- docs/WALLET_PARTNER_CONTACT_LOG_V1.md

## Conteúdo

O documento cobre:

- regra permanente antes de Pix/dinheiro real;
- status possíveis dos contatos;
- critérios de risco;
- primeira rodada recomendada de parceiros;
- registros iniciais para Celcoin, Dock, FitBank, Zoop, Stark Bank, Asaas, Efí Bank, iugu e Matera;
- registro de reuniões;
- registro de documentos recebidos;
- registro de decisões;
- checklist antes de aprovar candidato;
- bloqueios absolutos;
- próxima ação operacional.

## Diretriz de segurança

A Aurea Gold / dils-wallet continua sem Pix real, saldo real, liquidação real ou comprovante real até existir:

- PSP/BaaS homologado;
- contrato/parceria formal;
- KYC/KYB real;
- compliance;
- webhook assinado/tokenizado;
- ledger real separado;
- reconciliação oficial;
- plano de incidentes;
- operação/admin mínima;
- revisão jurídica/termos/política.

## Validação

- pre-commit OK
- git diff --cached --check OK