### PR TITLE
fix(security): block vulnerable fastapi 0.136.3

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi!=0.136.3
 uvicorn[standard]
 sqlalchemy
 pydantic


### PR DESCRIPTION
## Resumo

Bloqueia a resolução automática para fastapi 0.136.3, versão acusada pelo pip-audit como MAL-2026-4750.

## Escopo

- Altera somente backend/requirements.txt.
- Troca fastapi solto por fastapi!=0.136.3.
- Não altera frontend, Home, Gestão, Pix, Pagar ou Mais.

## Validação

- pip-audit local passou com: No known vulnerabilities found.

## Motivo

O requirement estava solto como fastapi, permitindo que o CI resolvesse para a versão afetada.