### PR TITLE
feat(wallet): add pay internal navigation

### DIFF
--- a/aurea-gold-client/src/pagamentos/AureaPagamentosPanel.tsx
+++ b/aurea-gold-client/src/pagamentos/AureaPagamentosPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   BellRing,
@@ -13,36 +13,164 @@ import {
   ShieldCheck,
 } from "lucide-react";
 
-type PagAction = "add-bill" | "subscription" | "boleto" | null;
+type PagAction =
+  | "add-bill"
+  | "boleto"
+  | "subscription"
+  | "card"
+  | "agenda"
+  | "alerts"
+  | "receipts"
+  | "history"
+  | "help";
+
+type PayPageInfo = {
+  key: PagAction;
+  title: string;
+  subtitle: string;
+  Icon: LucideIcon;
+  description: string;
+  detail: string;
+  statusLabel: string;
+  actionLabel: string;
+};
 
 type PayTileProps = {
   title: string;
   subtitle: string;
   Icon: LucideIcon;
   active?: boolean;
-  disabled?: boolean;
-  onClick?: () => void;
+  onClick: () => void;
 };
+
+const payPages: Record<PagAction, PayPageInfo> = {
+  "add-bill": {
+    key: "add-bill",
+    title: "Conta",
+    subtitle: "Cadastrar",
+    Icon: FileText,
+    description: "Cadastre contas a pagar, vencimentos e lembretes sem executar pagamento real.",
+    detail:
+      "Base operacional para organizar conta, valor, data de vencimento, status e recorrência. Pagamento real permanece bloqueado até parceiro financeiro homologado.",
+    statusLabel: "Organização segura",
+    actionLabel: "Salvar conta demo",
+  },
+  boleto: {
+    key: "boleto",
+    title: "Boleto",
+    subtitle: "Cobrança",
+    Icon: QrCode,
+    description: "Área preparada para leitura e organização de boleto.",
+    detail:
+      "Futura leitura de linha digitável/código de barras, vencimento e status. Pagamento real, liquidação real e comprovante real seguem bloqueados.",
+    statusLabel: "Boleto em modo seguro",
+    actionLabel: "Registrar boleto demo",
+  },
+  subscription: {
+    key: "subscription",
+    title: "Assina",
+    subtitle: "Recorrente",
+    Icon: Repeat,
+    description: "Organize assinaturas e compromissos recorrentes.",
+    detail:
+      "Controle de serviços mensais, impacto no caixa, vencimentos e alertas. Débito automático real não está ativo nesta etapa.",
+    statusLabel: "Recorrência preparada",
+    actionLabel: "Salvar assinatura demo",
+  },
+  card: {
+    key: "card",
+    title: "Cartão",
+    subtitle: "Parceiro",
+    Icon: CreditCard,
+    description: "Pagamentos com cartão dependem de parceiro homologado.",
+    detail:
+      "O app não processa cartão real sozinho. Qualquer operação com cartão físico, virtual, gateway ou Tap to Pay depende de PSP/BaaS, contrato, KYC/KYB e compliance.",
+    statusLabel: "Cartão real bloqueado",
+    actionLabel: "Ver requisitos do parceiro",
+  },
+  agenda: {
+    key: "agenda",
+    title: "Agenda",
+    subtitle: "Vencimentos",
+    Icon: CalendarClock,
+    description: "Agenda de vencimentos, contas e compromissos.",
+    detail:
+      "Central para organizar próximos pagamentos, datas importantes, previsões e rotinas financeiras sem movimentação real automática.",
+    statusLabel: "Agenda preparada",
+    actionLabel: "Criar lembrete demo",
+  },
+  alerts: {
+    key: "alerts",
+    title: "Alertas",
+    subtitle: "Lembretes",
+    Icon: BellRing,
+    description: "Alertas para vencimentos e rotinas financeiras.",
+    detail:
+      "Módulo para lembretes de contas, assinaturas e pagamentos futuros. Notificações reais serão tratadas em etapa própria.",
+    statusLabel: "Alertas em preparação",
+    actionLabel: "Configurar alerta demo",
+  },
+  receipts: {
+    key: "receipts",
+    title: "Recibos",
+    subtitle: "Sem fake",
+    Icon: ReceiptText,
+    description: "Recibos e comprovantes com regra de segurança.",
+    detail:
+      "Aurea não gera comprovante real falso. Recibos reais só existirão com liquidação confirmada por parceiro financeiro homologado e reconciliação oficial.",
+    statusLabel: "Sem comprovante fake",
+    actionLabel: "Ver política de recibos",
+  },
+  history: {
+    key: "history",
+    title: "Histórico",
+    subtitle: "Eventos",
+    Icon: History,
+    description: "Histórico de pagamentos e eventos operacionais.",
+    detail:
+      "Área para listar contas, boletos, assinaturas, simulações e eventos. Movimentação real será separada de demo/sandbox.",
+    statusLabel: "Histórico estruturado",
+    actionLabel: "Abrir histórico demo",
+  },
+  help: {
+    key: "help",
+    title: "Ajuda",
+    subtitle: "Suporte",
+    Icon: CircleHelp,
+    description: "Suporte para pagamentos, boletos e segurança.",
+    detail:
+      "Central de orientação para explicar limites, bloqueios, parceiro financeiro, comprovantes e regras de operação segura.",
+    statusLabel: "Suporte preparado",
+    actionLabel: "Abrir suporte",
+  },
+};
+
+const payCards = Object.values(payPages);
 
 function PayTile({
   title,
   subtitle,
   Icon,
   active = false,
-  disabled = false,
   onClick,
 }: PayTileProps) {
   return (
     <button
       type="button"
-      disabled={disabled}
       onClick={onClick}
       className={`flex flex-col items-center justify-center text-center shadow-[0_8px_18px_rgba(15,23,42,0.14)] transition active:scale-[0.98] ${
         active
           ? "bg-[linear-gradient(180deg,#F8E46D_0%,#D2A900_100%)] ring-2 ring-[#FFF1A6]"
           : "bg-[linear-gradient(180deg,#E9CF43_0%,#CBA500_100%)]"
-      } ${disabled ? "cursor-not-allowed opacity-70" : "hover:brightness-105"}`}
-      style={{ height: 72, width: "85%", justifySelf: "center", borderRadius: 15, padding: "8px 6px", boxSizing: "border-box" }}
+      } hover:brightness-105`}
+      style={{
+        height: 72,
+        width: "85%",
+        justifySelf: "center",
+        borderRadius: 15,
+        padding: "8px 6px",
+        boxSizing: "border-box",
+      }}
     >
       <div
         className="mb-1 flex items-center justify-center rounded-[14px] bg-white/18"
@@ -74,8 +202,98 @@ function PayTile({
 }
 
 export default function AureaPagamentosPanel() {
-  const [activeAction, setActiveAction] = useState<PagAction>(null);
+  const [activeAction, setActiveAction] = useState<PagAction | null>(null);
+  const activePage = activeAction ? payPages[activeAction] : null;
 
+  // PAGAR_EARLY_INTERNAL_PAGE_OK
+  if (activePage) {
+    const Icon = activePage.Icon;
+
+    return (
+      <section className="w-full max-w-[390px] sm:max-w-[430px] md:max-w-[960px] mx-auto px-4 pt-8 pb-32">
+        <section className="rounded-[30px] bg-[radial-gradient(circle_at_top_right,rgba(212,175,55,0.14),transparent_28%),linear-gradient(180deg,rgba(7,59,88,0.98),rgba(6,30,47,0.98))] px-5 pt-5 pb-6 text-white shadow-[0_14px_32px_rgba(0,0,0,0.18)]">
+          <button
+            type="button"
+            onClick={() => setActiveAction(null)}
+            className="inline-flex items-center rounded-full border border-emerald-300/30 bg-emerald-400/14 px-3 py-1 text-[11px] font-black text-emerald-200 shadow-[0_8px_18px_rgba(16,185,129,0.12)]"
+          >
+            ← Voltar para Pagar
+          </button>
+
+          <p className="mt-5 text-[10px] uppercase tracking-[0.18em] text-[#D4AF37]">
+            Pagar Aurea
+          </p>
+
+          <div className="mt-3 flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-[16px] bg-[linear-gradient(180deg,#E6C84F_0%,#C99A06_100%)] text-[#0A1F2E] shadow-[0_8px_18px_rgba(15,23,42,0.14)]">
+              <Icon size={24} strokeWidth={2.4} />
+            </div>
+
+            <h1
+              className="text-[#F5C842]"
+              style={{
+                fontSize: 26,
+                lineHeight: 1,
+                fontFamily: '"Arial Black", Arial, sans-serif',
+                fontWeight: 900,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {activePage.title}
+            </h1>
+          </div>
+
+          <p className="mt-3 text-[14px] leading-relaxed text-[#E6EDF5]">
+            {activePage.description}
+          </p>
+        </section>
+
+        <section className="mt-5 rounded-[28px] bg-[linear-gradient(180deg,#16364B_0%,#0D2436_100%)] px-5 pt-5 pb-6 text-[#f4f8ff] shadow-[0_10px_22px_rgba(0,0,0,0.12)]">
+          <p
+            className="text-[#F5C842]"
+            style={{
+              fontSize: 18,
+              lineHeight: 1,
+              fontFamily: '"Arial Black", Arial, sans-serif',
+              fontWeight: 900,
+            }}
+          >
+            {activePage.subtitle}
+          </p>
+
+          <p className="mt-3 text-[13px] leading-relaxed text-[#D7D0BE]">
+            {activePage.detail}
+          </p>
+
+          <div className="mt-5 rounded-[22px] border border-amber-500/16 bg-[rgba(12,30,42,0.74)] px-4 py-4">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+              Status operacional
+            </p>
+            <p className="mt-2 text-[13px] font-semibold leading-relaxed text-[#CBD5E1]">
+              {activePage.statusLabel}
+            </p>
+          </div>
+
+          <div className="mt-5 rounded-[22px] border border-white/12 bg-[linear-gradient(180deg,rgba(13,43,63,0.98),rgba(8,26,40,0.98))] px-4 py-4">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-[#D4AF37]">
+              Segurança financeira
+            </p>
+            <p className="mt-2 text-[12px] leading-relaxed text-[#B8AD95]">
+              Pagamento real, boleto real, cartão real, liquidação real e comprovante real permanecem bloqueados até PSP/BaaS homologado, contrato, KYC/KYB, compliance, webhook seguro, ledger e reconciliação oficiais.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            className="mt-5 w-full rounded-[18px] bg-[linear-gradient(180deg,#E6C84F_0%,#C99A06_100%)] px-4 py-3 text-[12px] font-black text-[#0A1F2E] shadow-[0_8px_18px_rgba(15,23,42,0.14)]"
+            style={{ fontFamily: '"Arial Black", Arial, sans-serif' }}
+          >
+            {activePage.actionLabel}
+          </button>
+        </section>
+      </section>
+    );
+  }
 
   return (
     <section className="w-full max-w-[390px] sm:max-w-[430px] md:max-w-[960px] mx-auto px-4 pt-8 pb-32">
@@ -114,68 +332,17 @@ export default function AureaPagamentosPanel() {
           Pagar rápido
         </div>
 
-        <div
-          className="mt-5 grid grid-cols-3"
-          style={{ gap: 8 }}
-        >
-          <PayTile
-            title="Conta"
-            subtitle="Cadastrar"
-            Icon={FileText}
-            active={activeAction === "add-bill"}
-            onClick={() => setActiveAction("add-bill")}
-          />
-          <PayTile
-            title="Boleto"
-            subtitle="Cobrança"
-            Icon={QrCode}
-            active={activeAction === "boleto"}
-            onClick={() => setActiveAction("boleto")}
-          />
-          <PayTile
-            title="Assina"
-            subtitle="Recorrente"
-            Icon={Repeat}
-            active={activeAction === "subscription"}
-            onClick={() => setActiveAction("subscription")}
-          />
-          <PayTile
-            title="Cartão"
-            subtitle="Parceiro"
-            Icon={CreditCard}
-            disabled
-          />
-          <PayTile
-            title="Agenda"
-            subtitle="Vencimentos"
-            Icon={CalendarClock}
-            active={activeAction === "add-bill"}
-            onClick={() => setActiveAction("add-bill")}
-          />
-          <PayTile
-            title="Alertas"
-            subtitle="Lembretes"
-            Icon={BellRing}
-            disabled
-          />
-          <PayTile
-            title="Recibos"
-            subtitle="Sem fake"
-            Icon={ReceiptText}
-            disabled
-          />
-          <PayTile
-            title="Histórico"
-            subtitle="Em breve"
-            Icon={History}
-            disabled
-          />
-          <PayTile
-            title="Ajuda"
-            subtitle="Suporte"
-            Icon={CircleHelp}
-            disabled
-          />
+        <div className="mt-5 grid grid-cols-3" style={{ gap: 8 }}>
+          {payCards.map((item) => (
+            <PayTile
+              key={item.key}
+              title={item.title}
+              subtitle={item.subtitle}
+              Icon={item.Icon}
+              active={activeAction === item.key}
+              onClick={() => setActiveAction(item.key)}
+            />
+          ))}
         </div>
 
         <div className="mt-6 rounded-[24px] border border-white/12 bg-[linear-gradient(180deg,rgba(13,43,63,0.98),rgba(8,26,40,0.98))] px-4 pt-4 pb-5 shadow-[0_12px_24px_rgba(0,0,0,0.16)]">
@@ -214,71 +381,6 @@ export default function AureaPagamentosPanel() {
               </div>
             </div>
           </div>
-        </div>
-
-        <div className="mt-5 rounded-[24px] border border-white/12 bg-white/[0.04] px-4 py-4 text-[14px] leading-relaxed text-[#CBD5E1]">
-          {!activeAction && (
-            <p>
-              Selecione uma ação para abrir a base operacional de pagamentos. Esta área organiza contas, boletos e rotinas recorrentes sem executar transação real.
-            </p>
-          )}
-
-          {activeAction === "add-bill" && (
-            <div className="space-y-2">
-              <h3
-                className="text-[#F8FAFC]"
-                style={{
-                  fontSize: 18,
-                  lineHeight: 1.1,
-                  fontFamily: '"Arial Black", Arial, sans-serif',
-                  fontWeight: 900,
-                }}
-              >
-                Adicionar conta
-              </h3>
-              <p>
-                Base para cadastrar conta a pagar, valor, vencimento, lembrete e status. Neste ciclo, o foco é organização; pagamento real segue bloqueado.
-              </p>
-            </div>
-          )}
-
-          {activeAction === "subscription" && (
-            <div className="space-y-2">
-              <h3
-                className="text-[#F8FAFC]"
-                style={{
-                  fontSize: 18,
-                  lineHeight: 1.1,
-                  fontFamily: '"Arial Black", Arial, sans-serif',
-                  fontWeight: 900,
-                }}
-              >
-                Assinaturas recorrentes
-              </h3>
-              <p>
-                Espaço para mapear serviços mensais, impacto no caixa e futuros alertas automáticos, sem débito automático real nesta etapa.
-              </p>
-            </div>
-          )}
-
-          {activeAction === "boleto" && (
-            <div className="space-y-2">
-              <h3
-                className="text-[#F8FAFC]"
-                style={{
-                  fontSize: 18,
-                  lineHeight: 1.1,
-                  fontFamily: '"Arial Black", Arial, sans-serif',
-                  fontWeight: 900,
-                }}
-              >
-                Cobrança com boleto
-              </h3>
-              <p>
-                Base visual para futura emissão e acompanhamento de boletos via parceiro homologado. Não gera boleto real, linha digitável real ou cobrança real.
-              </p>
-            </div>
-          )}
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Resumo

- Adiciona navegação interna premium na aba Pagar.
- Todos os 9 cards internos passam a abrir página própria:
  - Conta
  - Boleto
  - Assina
  - Cartão
  - Agenda
  - Alertas
  - Recibos
  - Histórico
  - Ajuda
- Mantém padrão visual aprovado dos cards: altura fixa, grid 3x3, Arial Black, ícones Lucide e layout mobile premium.
- Preserva mensagens de segurança: pagamento real, boleto real, cartão real, liquidação real e comprovante real continuam bloqueados até PSP/BaaS homologado.

## Validação

- pre-commit OK.
- Frontend build OK.
- Teste mobile local OK.
- Pagar validado com páginas internas funcionando.
- Bloqueio de operação real preservado.

## Observação de produto

A Aurea Gold segue como carteira/produto financeiro real em evolução. Nenhuma operação financeira real foi liberada neste PR.