### PR TITLE
docs(wallet): add partner contact channels and outreach v1

### DIFF
--- a/docs/WALLET_PARTNER_CONTACT_CHANNELS_AND_OUTREACH_V1.md
+++ b/docs/WALLET_PARTNER_CONTACT_CHANNELS_AND_OUTREACH_V1.md
@@ -1,0 +1,308 @@
+# Aurea Gold / dils-wallet — Partner Contact Channels & Outreach v1
+
+## 1. Objetivo
+
+Este documento organiza a primeira rodada de abordagem da Aurea Gold / dils-wallet a parceiros PSP/BaaS.
+
+Ele define:
+
+- parceiros prioritários;
+- canal inicial de contato;
+- mensagem curta para formulário, WhatsApp ou LinkedIn;
+- e-mail profissional;
+- perguntas mínimas para primeira resposta;
+- regra de registro no log;
+- critérios para avançar ou descartar.
+
+Este documento é operacional. Ele serve para enviar as primeiras mensagens e controlar a abordagem.
+
+## 2. Regra-mãe
+
+A Aurea Gold é um produto financeiro real em construção para mercado.
+
+Não é projeto de estudo.
+Não é carteira fake.
+Não movimenta dinheiro real hoje.
+Não deve prometer Pix real, saldo real, boleto real, cartão real, checkout real, comprovante real ou liquidação real sem parceiro homologado.
+
+Mensagem correta:
+
+> A Aurea Gold já possui produto, interface, fluxos, sandbox, documentação e travas de segurança. A operação financeira real será ativada somente com parceiro PSP/BaaS homologado, contrato, KYC/KYB, compliance, webhooks seguros, ledger, reconciliação e revisão jurídica.
+
+## 3. Estado atual para apresentar
+
+Marcos atuais:
+
+- v0.2.20-wallet-final-visual-polish
+- v0.2.21-wallet-partner-presentation-readiness
+
+Estado atual:
+
+- UI mobile premium aprovada como base visual.
+- Conta, Pix, Gestão, Pagar, Mais e Planos estruturados.
+- Pix sandbox documentado.
+- Valor demonstrativo sandbox zerado para R$ 0,00.
+- Dinheiro real bloqueado.
+- Separação demo/sandbox/produção preservada.
+- Documentação de prontidão criada.
+- Próximo foco: conversar com PSP/BaaS.
+
+## 4. Ordem recomendada de abordagem
+
+### Primeira onda
+
+1. Celcoin
+2. FitBank/Fits
+3. Dock
+4. Zoop
+
+Motivo: maior aderência inicial a BaaS, Pix, Banking, infraestrutura, contas, APIs ou white label.
+
+### Segunda onda
+
+5. Efí Bank
+6. Asaas
+7. Stark Bank
+
+Motivo: podem ajudar em Pix, cobrança, API, pagamentos ou operação inicial, mas exigem validação forte para wallet, saldo por usuário, ledger e compliance.
+
+### Terceira onda
+
+8. iugu
+9. Matera
+
+Motivo: iugu pode ser mais forte em cobrança/recorrência; Matera pode ser mais enterprise/institucional.
+
+## 5. Tabela operacional de contato
+
+| Prioridade | Parceiro | Tipo provável | Canal inicial recomendado | Observação |
+|---:|---|---|---|---|
+| 1 | Celcoin | BaaS / Core / Pix / Infra financeira | Formulário oficial / Fale com especialista / contato comercial | Melhor candidato inicial para validar wallet real, Pix, cash-in/cash-out, ledger e modelo regulatório. |
+| 2 | FitBank/Fits | BaaS / Pix API / white label | comercial@fitbank.com.br | Bom candidato por APIs, Pix, onboarding, saldo/extrato e white label. |
+| 3 | Dock | BaaS / Banking / Pix B2B | Formulário “Falar com o Comercial” | Forte, mas pode exigir porte, contrato e critérios enterprise. |
+| 4 | Zoop | Banking API / pagamentos / white label | Site oficial / Fale conosco / formulário comercial | Validar se atende wallet com saldo por usuário e responsabilidades regulatórias. |
+| 5 | Efí Bank | Pix API / pagamentos / dev friendly | WhatsApp/comercial oficial | Boa alternativa para Pix/API/cobrança; validar wallet, saldo por cliente e compliance. |
+| 6 | Asaas | API de pagamentos / Pix / cobranças | WhatsApp/e-mail/formulário comercial | Pode ser caminho rápido para cobrança/pagamentos; validar se resolve wallet/ledger. |
+| 7 | Stark Bank | Banking API / Pix / pagamentos corporativos | Contact Sales / e-mail comercial | Forte API empresarial; validar aderência para carteira com usuários finais. |
+| 8 | iugu | Cobrança / Pix / recorrência / API | Site oficial / especialista / suporte/API | Boa para cobrança/recorrência; validar se atende BaaS/wallet. |
+| 9 | Matera | Core / Pix as a Service / infraestrutura financeira | Formulário oficial | Forte infraestrutura; pode ser mais enterprise. |
+
+## 6. Mensagem curta para primeiro contato
+
+Usar em formulário, WhatsApp ou LinkedIn:
+
+Olá, tudo bem?
+
+Meu nome é Dilson Pereira. Estou desenvolvendo a Aurea Gold, uma carteira digital em construção para mercado, com foco em Pix, saldo, pagamentos, gestão financeira, auditoria e experiência mobile premium.
+
+Hoje o produto já possui interface, fluxos, sandbox, documentação técnica e travas de segurança. A operação financeira real está intencionalmente bloqueada até termos um parceiro PSP/BaaS homologado.
+
+Gostaria de falar com o time comercial/técnico para entender se vocês atendem uma parceria para habilitar Pix, saldo, webhook, ledger/reconciliação, KYC/KYB e operação real via infraestrutura de parceiro.
+
+Podemos agendar uma conversa rápida?
+
+## 7. Mensagem curta alternativa
+
+Olá! Estou buscando parceiro PSP/BaaS para a Aurea Gold, uma carteira digital em construção com Pix, saldo, pagamentos, gestão financeira e app mobile premium. O produto já tem sandbox, documentação e travas de segurança; dinheiro real só será ativado com parceiro homologado. Gostaria de falar com o time comercial/técnico para validar integração, Pix, webhook, ledger, KYC/KYB e modelo de parceria.
+
+## 8. E-mail profissional
+
+Assunto:
+
+Parceria PSP/BaaS para carteira digital Aurea Gold
+
+Corpo:
+
+Olá, tudo bem?
+
+Meu nome é Dilson Pereira e estou desenvolvendo a Aurea Gold / dils-wallet, uma carteira digital em construção para mercado.
+
+A Aurea Gold tem como objetivo oferecer uma experiência mobile premium para conta digital, Pix, pagamentos, gestão financeira, relatórios, suporte, planos comerciais e operação assistida.
+
+O produto já possui:
+
+- interface mobile premium validada;
+- fluxos de Conta, Pix, Gestão, Pagar, Mais e Planos;
+- sandbox Pix documentado;
+- blocos de segurança, limites, KYC/KYB e auditoria;
+- separação entre demo, sandbox e produção;
+- travas para impedir dinheiro real antes de parceiro homologado;
+- documentação de prontidão para integração com PSP/BaaS.
+
+Estamos buscando um parceiro financeiro para validar a viabilidade de operação real com:
+
+- Pix de entrada;
+- Pix de saída;
+- consulta de saldo;
+- extrato;
+- webhooks assinados;
+- ledger/reconciliação;
+- KYC/KYB;
+- limites e risco;
+- comprovantes oficiais;
+- modelo comercial e regulatório compatível.
+
+Importante: hoje a Aurea Gold não movimenta dinheiro real. Essa é uma decisão intencional de segurança. A operação real só será ativada após parceria formal, homologação técnica, compliance, revisão jurídica e validação operacional.
+
+Gostaria de falar com o time comercial/técnico de vocês para entender:
+
+1. Se o modelo da Aurea Gold se encaixa nas soluções de vocês.
+2. Quais APIs e ambientes de sandbox estão disponíveis.
+3. Como funcionam KYC/KYB, ledger, webhooks, reconciliação e responsabilidades.
+4. Quais são os requisitos comerciais e contratuais para avançarmos.
+
+Podemos agendar uma conversa inicial?
+
+Obrigado,
+Dilson Pereira
+Aurea Gold / dils-wallet
+
+## 9. Perguntas mínimas para primeira resposta
+
+1. Vocês atendem modelo de carteira digital/app financeiro com Pix e saldo por usuário?
+2. A solução é PSP, BaaS, Banking API, gateway ou combinação?
+3. Existe sandbox oficial?
+4. A API suporta Pix de entrada/cobrança?
+5. A API suporta Pix de saída/pagamento?
+6. Existe consulta de saldo e extrato?
+7. Os webhooks são assinados?
+8. Existe idempotência e retry de eventos?
+9. Como funcionam KYC e KYB?
+10. É possível operar com subcontas, contas transacionais ou ledger por cliente?
+11. Quem é o responsável regulatório pela conta/operação?
+12. Como funciona comprovante oficial?
+13. Como funciona reconciliação?
+14. Quais são os custos: setup, mensalidade, transação, Pix, saque, boleto, suporte?
+15. Qual o prazo de homologação?
+
+## 10. Critérios para avançar
+
+Avançar se o parceiro confirmar:
+
+- sandbox oficial;
+- Pix entrada ou cobrança;
+- webhooks;
+- consulta de status;
+- documentação técnica;
+- modelo comercial viável;
+- KYC/KYB ou caminho claro para isso;
+- possibilidade de operação real com segurança;
+- clareza sobre responsabilidades regulatórias.
+
+Não avançar se:
+
+- não houver documentação;
+- não houver sandbox;
+- não houver clareza sobre KYC/KYB;
+- não houver webhooks confiáveis;
+- não houver suporte técnico;
+- não houver resposta sobre responsabilidade regulatória;
+- o modelo for apenas gateway simples e não atender a visão da wallet.
+
+## 11. Como registrar cada contato
+
+Depois de cada envio, atualizar:
+
+`docs/WALLET_PARTNER_CONTACT_LOG_V1.md`
+
+Registrar:
+
+- data;
+- parceiro;
+- canal usado;
+- mensagem enviada;
+- pessoa/time contatado, se houver;
+- resposta recebida;
+- documentos enviados/recebidos;
+- próxima ação;
+- decisão atual.
+
+Status possíveis:
+
+- pendente;
+- contato enviado;
+- respondeu;
+- reunião agendada;
+- em análise técnica;
+- descartado;
+- aprovado para próxima fase.
+
+## 12. Rodada prática de envio
+
+### Rodada 1
+
+Enviar para:
+
+1. Celcoin
+2. FitBank/Fits
+3. Dock
+4. Zoop
+
+### Rodada 2
+
+Se a primeira rodada demorar ou não encaixar:
+
+5. Efí Bank
+6. Asaas
+7. Stark Bank
+
+### Rodada 3
+
+Se necessário:
+
+8. iugu
+9. Matera
+
+## 13. Documentos internos de apoio
+
+Usar para consulta interna:
+
+- docs/WALLET_PARTNER_PRESENTATION_READINESS_V1.md
+- docs/WALLET_PSP_BAAS_QUESTIONNAIRE_V1.md
+- docs/WALLET_PARTNER_READINESS_MATRIX_V1.md
+- docs/WALLET_PRODUCTION_ENV_CHECKLIST_V1.md
+- docs/WALLET_SANDBOX_CYCLE_RUNBOOK.md
+- docs/WALLET_REAL_READINESS_AUDIT.md
+
+Não enviar todos automaticamente.
+
+Enviar apenas se o parceiro pedir ou usar como base para reunião.
+
+## 14. Regras de segurança
+
+Não enviar:
+
+- chaves de API;
+- dados sensíveis;
+- prints com tokens;
+- credenciais;
+- banco de dados;
+- segredos .env;
+- dados pessoais sem base legal;
+- promessa de operação real já ativa.
+
+Pode enviar:
+
+- explicação do produto;
+- visão de parceria;
+- requisitos técnicos;
+- perguntas do questionário;
+- status de prontidão;
+- escopo desejado;
+- demonstração visual sem dinheiro real.
+
+## 15. Próximo passo
+
+1. Revisar canais de contato prioritários.
+2. Enviar primeira rodada.
+3. Atualizar log de contatos.
+4. Aguardar resposta.
+5. Agendar reunião técnica.
+6. Validar requisitos com o questionário PSP/BaaS.
+7. Escolher candidato para sandbox oficial.
+
+## 16. Estado deste documento
+
+Status: v1 criado após `v0.2.21-wallet-partner-presentation-readiness`.
+
+Este documento marca o início operacional da abordagem da Aurea Gold a parceiros PSP/BaaS.


### PR DESCRIPTION
## Resumo

Este PR adiciona o guia operacional para abordagem da Aurea Gold / dils-wallet a parceiros PSP/BaaS.

### Entregas

- Define ordem recomendada de abordagem dos parceiros.
- Organiza primeira, segunda e terceira onda de contatos.
- Lista canais iniciais recomendados por parceiro.
- Inclui mensagem curta para WhatsApp, LinkedIn ou formulário.
- Inclui e-mail profissional para primeira abordagem.
- Lista perguntas mínimas para primeira resposta.
- Define critérios para avançar ou descartar parceiro.
- Define regra de registro no log de contatos.
- Reforça que a Aurea Gold é produto financeiro real em construção.
- Mantém a regra de segurança antes de dinheiro real.

### Segurança

Este PR não altera código.
Não libera operação financeira real.
Não altera Pix, saldo, checkout, boleto, cartão ou comprovante.
Não remove bloqueios demo/sandbox/produção.

### Validação

- Documento criado em docs/WALLET_PARTNER_CONTACT_CHANNELS_AND_OUTREACH_V1.md
- Estrutura revisada por headings
- Base atual: v0.2.21-wallet-partner-presentation-readiness