### PR TITLE
feat(wallet): add Asaas sandbox config guards

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,7 +18,7 @@ REAL_MONEY_ENABLED=false
 # ------------------------------------------------------------
 
 ASAAS_ENV=sandbox
-ASAAS_BASE_URL=<CONFIRMAR_URL_BASE_SANDBOX_OFICIAL_ASAAS>
+ASAAS_BASE_URL=https://sandbox.asaas.com/api/v3
 
 # Sensitive values.
 # Never commit real values.

--- a/backend/app/partner/asaas_config.py
+++ b/backend/app/partner/asaas_config.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+
+ASAAS_SANDBOX_BASE_URL = "https://sandbox.asaas.com/api/v3"
+ASAAS_PRODUCTION_BASE_URL = "https://api.asaas.com/v3"
+
+
+class AsaasConfigError(RuntimeError):
+    """Raised when Asaas Sandbox safety guards reject the configuration."""
+
+
+@dataclass(frozen=True)
+class AsaasSandboxConfig:
+    env: str
+    base_url: str
+    api_key: str
+    webhook_token: str
+    real_money_enabled: bool
+    wallet_mode: str
+    wallet_partner_provider: str
+
+    def __repr__(self) -> str:
+        return (
+            "AsaasSandboxConfig("
+            f"env={self.env!r}, "
+            f"base_url={self.base_url!r}, "
+            "api_key='<masked>', "
+            "webhook_token='<masked>', "
+            f"real_money_enabled={self.real_money_enabled!r}, "
+            f"wallet_mode={self.wallet_mode!r}, "
+            f"wallet_partner_provider={self.wallet_partner_provider!r}"
+            ")"
+        )
+
+    def safe_summary(self) -> dict[str, object]:
+        return {
+            "env": self.env,
+            "base_url": self.base_url,
+            "api_key_configured": bool(self.api_key),
+            "webhook_token_configured": bool(self.webhook_token),
+            "real_money_enabled": self.real_money_enabled,
+            "wallet_mode": self.wallet_mode,
+            "wallet_partner_provider": self.wallet_partner_provider,
+            "http_calls_allowed": False,
+        }
+
+
+def _get(env: Mapping[str, str], key: str, default: str = "") -> str:
+    return (env.get(key, default) or "").strip()
+
+
+def _normalized_base_url(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _is_placeholder(value: str) -> bool:
+    cleaned = value.strip()
+    return not cleaned or (cleaned.startswith("<") and cleaned.endswith(">"))
+
+
+def _is_true(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def load_asaas_sandbox_config(
+    env: Mapping[str, str] | None = None,
+) -> AsaasSandboxConfig:
+    """
+    Load and validate Asaas Sandbox configuration.
+
+    This function is intentionally strict and performs no HTTP calls.
+    It only approves a configuration that is safe for Sandbox preparation.
+    """
+    source = os.environ if env is None else env
+
+    wallet_mode = _get(source, "WALLET_MODE", "demo").lower()
+    wallet_partner_provider = _get(source, "WALLET_PARTNER_PROVIDER", "").lower()
+    real_money_raw = _get(source, "REAL_MONEY_ENABLED", "false")
+    asaas_env = _get(source, "ASAAS_ENV", "").lower()
+    base_url = _normalized_base_url(_get(source, "ASAAS_BASE_URL", ""))
+    api_key = _get(source, "ASAAS_API_KEY", "")
+    webhook_token = _get(source, "ASAAS_WEBHOOK_TOKEN", "")
+
+    if wallet_mode != "partner":
+        raise AsaasConfigError("WALLET_MODE must be partner for Asaas Sandbox.")
+
+    if wallet_partner_provider != "asaas":
+        raise AsaasConfigError("WALLET_PARTNER_PROVIDER must be asaas.")
+
+    if _is_true(real_money_raw):
+        raise AsaasConfigError("REAL_MONEY_ENABLED must remain false for Sandbox.")
+
+    if asaas_env != "sandbox":
+        raise AsaasConfigError("ASAAS_ENV must be sandbox.")
+
+    if base_url == ASAAS_PRODUCTION_BASE_URL:
+        raise AsaasConfigError("Production Asaas base URL is blocked.")
+
+    if base_url != ASAAS_SANDBOX_BASE_URL:
+        raise AsaasConfigError("ASAAS_BASE_URL must be the official Sandbox URL.")
+
+    if _is_placeholder(api_key):
+        raise AsaasConfigError("ASAAS_API_KEY must be configured outside Git.")
+
+    if _is_placeholder(webhook_token):
+        raise AsaasConfigError("ASAAS_WEBHOOK_TOKEN must be configured outside Git.")
+
+    return AsaasSandboxConfig(
+        env=asaas_env,
+        base_url=base_url,
+        api_key=api_key,
+        webhook_token=webhook_token,
+        real_money_enabled=False,
+        wallet_mode=wallet_mode,
+        wallet_partner_provider=wallet_partner_provider,
+    )

--- a/backend/tests/test_asaas_config_guards.py
+++ b/backend/tests/test_asaas_config_guards.py
@@ -1,0 +1,86 @@
+import pytest
+
+from app.partner.asaas_config import (
+    ASAAS_SANDBOX_BASE_URL,
+    AsaasConfigError,
+    load_asaas_sandbox_config,
+)
+
+
+VALID_ENV = {
+    "WALLET_MODE": "partner",
+    "WALLET_PARTNER_PROVIDER": "asaas",
+    "REAL_MONEY_ENABLED": "false",
+    "ASAAS_ENV": "sandbox",
+    "ASAAS_BASE_URL": ASAAS_SANDBOX_BASE_URL,
+    "ASAAS_API_KEY": "sandbox-api-key-for-test-only",
+    "ASAAS_WEBHOOK_TOKEN": "sandbox-webhook-token-for-test-only",
+}
+
+
+def test_load_asaas_sandbox_config_accepts_safe_sandbox_env():
+    config = load_asaas_sandbox_config(VALID_ENV)
+
+    assert config.env == "sandbox"
+    assert config.base_url == ASAAS_SANDBOX_BASE_URL
+    assert config.wallet_mode == "partner"
+    assert config.wallet_partner_provider == "asaas"
+    assert config.real_money_enabled is False
+
+
+def test_load_asaas_sandbox_config_safe_summary_does_not_leak_secrets():
+    config = load_asaas_sandbox_config(VALID_ENV)
+
+    summary = config.safe_summary()
+
+    assert summary["api_key_configured"] is True
+    assert summary["webhook_token_configured"] is True
+    assert summary["http_calls_allowed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(config)
+    assert "sandbox-webhook-token-for-test-only" not in repr(config)
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("WALLET_MODE", "demo", "WALLET_MODE must be partner"),
+        ("WALLET_PARTNER_PROVIDER", "demo", "WALLET_PARTNER_PROVIDER must be asaas"),
+        ("REAL_MONEY_ENABLED", "true", "REAL_MONEY_ENABLED must remain false"),
+        ("ASAAS_ENV", "production", "ASAAS_ENV must be sandbox"),
+        (
+            "ASAAS_BASE_URL",
+            "https://api.asaas.com/v3",
+            "Production Asaas base URL is blocked",
+        ),
+        (
+            "ASAAS_BASE_URL",
+            "https://example.com/api/v3",
+            "ASAAS_BASE_URL must be the official Sandbox URL",
+        ),
+        (
+            "ASAAS_API_KEY",
+            "<DEFINIR_APENAS_NO_ENV_LOCAL_SEGURO>",
+            "ASAAS_API_KEY must be configured outside Git",
+        ),
+        (
+            "ASAAS_WEBHOOK_TOKEN",
+            "<DEFINIR_APENAS_NO_ENV_LOCAL_SEGURO>",
+            "ASAAS_WEBHOOK_TOKEN must be configured outside Git",
+        ),
+    ],
+)
+def test_load_asaas_sandbox_config_rejects_unsafe_env(key, value, message):
+    env = dict(VALID_ENV)
+    env[key] = value
+
+    with pytest.raises(AsaasConfigError, match=message):
+        load_asaas_sandbox_config(env)
+
+
+def test_load_asaas_sandbox_config_normalizes_trailing_slash():
+    env = dict(VALID_ENV)
+    env["ASAAS_BASE_URL"] = f"{ASAAS_SANDBOX_BASE_URL}/"
+
+    config = load_asaas_sandbox_config(env)
+
+    assert config.base_url == ASAAS_SANDBOX_BASE_URL

--- a/docs/WALLET_ASAAS_SANDBOX_CONFIG_GUARDS_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_CONFIG_GUARDS_V1.md
@@ -1,0 +1,163 @@
+# Aurea Gold / dils-wallet — Asaas Sandbox Config Guards V1
+
+Marco planejado: v0.2.40-wallet-asaas-sandbox-config-guards
+
+Status: primeiro codigo seguro da integracao Asaas Sandbox.
+
+Este marco adiciona guardas de configuracao para a integracao Asaas Sandbox.
+
+Nao ha chamada HTTP neste marco.
+
+Nao ha Pix real neste marco.
+
+Nao ha saldo real neste marco.
+
+Nao ha producao neste marco.
+
+Nao ha API Key real, token real ou Wallet ID real no Git.
+
+## 1. Objetivo
+
+Criar uma camada pequena e testavel para validar se a configuracao local do Asaas Sandbox esta segura antes de qualquer futura chamada de API.
+
+O objetivo principal e impedir uso acidental de producao, dinheiro real ou segredo em local inseguro.
+
+## 2. Arquivos criados ou alterados
+
+Arquivos criados:
+
+- backend/app/partner/asaas_config.py
+- backend/tests/test_asaas_config_guards.py
+- docs/WALLET_ASAAS_SANDBOX_CONFIG_GUARDS_V1.md
+
+Arquivo alterado:
+
+- backend/.env.example
+
+## 3. Guardas implementadas
+
+A funcao load_asaas_sandbox_config valida:
+
+- WALLET_MODE=partner
+- WALLET_PARTNER_PROVIDER=asaas
+- REAL_MONEY_ENABLED=false
+- ASAAS_ENV=sandbox
+- ASAAS_BASE_URL=https://sandbox.asaas.com/api/v3
+- ASAAS_API_KEY configurada fora do Git
+- ASAAS_WEBHOOK_TOKEN configurado fora do Git
+
+A configuracao e rejeitada se:
+
+- WALLET_MODE nao for partner;
+- WALLET_PARTNER_PROVIDER nao for asaas;
+- REAL_MONEY_ENABLED estiver true;
+- ASAAS_ENV nao for sandbox;
+- ASAAS_BASE_URL apontar para producao;
+- ASAAS_BASE_URL nao for a URL Sandbox oficial;
+- ASAAS_API_KEY estiver vazia ou com placeholder;
+- ASAAS_WEBHOOK_TOKEN estiver vazio ou com placeholder.
+
+## 4. Bloqueio contra producao
+
+A URL de producao do Asaas e explicitamente bloqueada:
+
+https://api.asaas.com/v3
+
+A URL Sandbox oficial permitida e:
+
+https://sandbox.asaas.com/api/v3
+
+## 5. Segredos protegidos
+
+O modulo Asaas Sandbox nao deve expor segredo em representacao textual.
+
+O metodo __repr__ mascara:
+
+- api_key
+- webhook_token
+
+O metodo safe_summary informa apenas se os valores foram configurados, sem mostrar o conteudo.
+
+## 6. Sem chamada externa
+
+Este marco nao cria cliente HTTP.
+
+Este marco nao chama API do Asaas.
+
+Este marco nao cria cliente pagador.
+
+Este marco nao cria cobranca Pix.
+
+Este marco nao consulta QR Code.
+
+Este marco nao recebe webhook real.
+
+Este marco apenas prepara as travas de seguranca.
+
+## 7. Testes adicionados
+
+Teste criado:
+
+- backend/tests/test_asaas_config_guards.py
+
+Cenarios cobertos:
+
+- aceita configuracao Sandbox segura;
+- nao vaza API Key no repr;
+- nao vaza webhook token no repr;
+- rejeita WALLET_MODE incorreto;
+- rejeita WALLET_PARTNER_PROVIDER incorreto;
+- rejeita REAL_MONEY_ENABLED=true;
+- rejeita ASAAS_ENV=production;
+- rejeita URL de producao;
+- rejeita URL desconhecida;
+- rejeita API Key placeholder;
+- rejeita webhook token placeholder;
+- normaliza barra final na URL Sandbox.
+
+## 8. Validacao local
+
+Comando executado:
+
+pytest tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+11 passed
+
+## 9. Atualizacao do backend/.env.example
+
+O backend/.env.example foi atualizado para registrar a URL Sandbox oficial confirmada pelo Asaas:
+
+ASAAS_BASE_URL=https://sandbox.asaas.com/api/v3
+
+O arquivo continua sem segredo real.
+
+Os campos sensiveis permanecem com placeholders seguros:
+
+- ASAAS_API_KEY
+- ASAAS_WEBHOOK_TOKEN
+
+## 10. Criterios de sucesso
+
+Este marco e considerado concluido quando:
+
+- os arquivos forem criados;
+- backend/.env.example continuar sem segredo real;
+- pytest do teste Asaas passar;
+- git diff --check passar;
+- o PR passar nos checks;
+- o PR for mergeado;
+- a tag oficial for criada.
+
+Tag esperada:
+
+v0.2.40-wallet-asaas-sandbox-config-guards
+
+## 11. Proximo marco provavel
+
+Proximo marco provavel:
+
+v0.2.41-wallet-asaas-sandbox-client-skeleton
+
+Esse proximo marco pode criar o esqueleto do cliente Asaas Sandbox, ainda com cuidado para nao executar chamada real sem travas aprovadas.


### PR DESCRIPTION
## Resumo
- adiciona guardas de configuracao para Asaas Sandbox
- valida WALLET_MODE=partner, WALLET_PARTNER_PROVIDER=asaas, ASAAS_ENV=sandbox e REAL_MONEY_ENABLED=false
- bloqueia explicitamente URL de producao do Asaas
- mascara API Key e webhook token em representacao segura
- atualiza backend/.env.example com a URL Sandbox oficial confirmada
- adiciona testes automatizados para configuracoes seguras e inseguras
- documenta o marco v0.2.40

## Seguranca
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- sem Pix real
- sem saldo real
- sem chamada HTTP
- sem producao

## Validacao local
- cd backend && pytest tests/test_asaas_config_guards.py -q
- resultado: 11 passed

## Proximo marco provavel
v0.2.41-wallet-asaas-sandbox-client-skeleton