### PR TITLE
feat(wallet): add Asaas sandbox client skeleton

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Literal
+
+from app.partner.asaas_config import AsaasSandboxConfig, load_asaas_sandbox_config
+
+
+AsaasHttpMethod = Literal["GET", "POST"]
+
+
+@dataclass(frozen=True)
+class AsaasPreparedRequest:
+    method: AsaasHttpMethod
+    url: str
+    operation: str
+    json: dict[str, Any] | None = None
+    headers_configured: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "method": self.method,
+            "url": self.url,
+            "operation": self.operation,
+            "json": self.json,
+            "headers_configured": self.headers_configured,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "raw": self.raw,
+        }
+
+
+class AsaasSandboxClient:
+    """
+    Skeleton client for Asaas Sandbox.
+
+    Safety rule:
+    - This milestone prepares request metadata only.
+    - It does not perform HTTP calls.
+    - It does not create real Pix charges.
+    - It does not move real money.
+    """
+
+    def __init__(self, config: AsaasSandboxConfig | None = None) -> None:
+        self.config = config or load_asaas_sandbox_config()
+
+    @property
+    def base_url(self) -> str:
+        return self.config.base_url.rstrip("/")
+
+    def _prepare(
+        self,
+        *,
+        method: AsaasHttpMethod,
+        path: str,
+        operation: str,
+        json: dict[str, Any] | None = None,
+    ) -> AsaasPreparedRequest:
+        normalized_path = "/" + path.lstrip("/")
+
+        return AsaasPreparedRequest(
+            method=method,
+            url=f"{self.base_url}{normalized_path}",
+            operation=operation,
+            json=json,
+            headers_configured=bool(self.config.api_key),
+            real_money=False,
+            http_call_executed=False,
+            raw={
+                "sandbox": True,
+                "provider": "asaas",
+                "env": self.config.env,
+                "http_execution_blocked": True,
+            },
+        )
+
+    def prepare_create_customer(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+    ) -> AsaasPreparedRequest:
+        payload = {
+            "name": name,
+            "cpfCnpj": cpf_cnpj,
+            "email": email,
+            "mobilePhone": mobile_phone,
+        }
+
+        return self._prepare(
+            method="POST",
+            path="/customers",
+            operation="create_customer",
+            json=payload,
+        )
+
+    def prepare_create_pix_payment(
+        self,
+        *,
+        customer_id: str,
+        value: Decimal,
+        due_date: str,
+        description: str,
+    ) -> AsaasPreparedRequest:
+        payload = {
+            "customer": customer_id,
+            "billingType": "PIX",
+            "value": float(value),
+            "dueDate": due_date,
+            "description": description,
+        }
+
+        return self._prepare(
+            method="POST",
+            path="/payments",
+            operation="create_pix_payment",
+            json=payload,
+        )
+
+    def prepare_get_pix_qr_code(self, *, payment_id: str) -> AsaasPreparedRequest:
+        return self._prepare(
+            method="GET",
+            path=f"/payments/{payment_id}/pixQrCode",
+            operation="get_pix_qr_code",
+        )
+
+    def prepare_get_payment_status(self, *, payment_id: str) -> AsaasPreparedRequest:
+        return self._prepare(
+            method="GET",
+            path=f"/payments/{payment_id}",
+            operation="get_payment_status",
+        )
+
+    def execute_prepared_request(self, request: AsaasPreparedRequest) -> None:
+        raise RuntimeError(
+            "HTTP execution is intentionally blocked in this milestone. "
+            f"Operation {request.operation!r} was prepared but not executed."
+        )

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -1,0 +1,118 @@
+from decimal import Decimal
+
+import pytest
+
+from app.partner.asaas_client import AsaasSandboxClient
+from app.partner.asaas_config import ASAAS_SANDBOX_BASE_URL, AsaasSandboxConfig
+
+
+TEST_CONFIG = AsaasSandboxConfig(
+    env="sandbox",
+    base_url=ASAAS_SANDBOX_BASE_URL,
+    api_key="sandbox-api-key-for-test-only",
+    webhook_token="sandbox-webhook-token-for-test-only",
+    real_money_enabled=False,
+    wallet_mode="partner",
+    wallet_partner_provider="asaas",
+)
+
+
+def make_client() -> AsaasSandboxClient:
+    return AsaasSandboxClient(config=TEST_CONFIG)
+
+
+def test_prepare_create_customer_builds_sandbox_request_without_http_call():
+    client = make_client()
+
+    request = client.prepare_create_customer(
+        name="Cliente Sandbox Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.sandbox@example.com",
+        mobile_phone="11999999999",
+    )
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.headers_configured is True
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Sandbox Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.sandbox@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
+    client = make_client()
+
+    request = client.prepare_create_pix_payment(
+        customer_id="cus_xxxxxxxx",
+        value=Decimal("50.00"),
+        due_date="2026-07-10",
+        description="Teste cobranca Pix Sandbox Aurea Gold",
+    )
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments"
+    assert request.operation == "create_pix_payment"
+    assert request.headers_configured is True
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "customer": "cus_xxxxxxxx",
+        "billingType": "PIX",
+        "value": 50.0,
+        "dueDate": "2026-07-10",
+        "description": "Teste cobranca Pix Sandbox Aurea Gold",
+    }
+
+
+def test_prepare_get_pix_qr_code_builds_sandbox_request_without_http_call():
+    client = make_client()
+
+    request = client.prepare_get_pix_qr_code(payment_id="pay_xxxxxxxx")
+
+    assert request.method == "GET"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments/pay_xxxxxxxx/pixQrCode"
+    assert request.operation == "get_pix_qr_code"
+    assert request.json is None
+    assert request.real_money is False
+    assert request.http_call_executed is False
+
+
+def test_prepare_get_payment_status_builds_sandbox_request_without_http_call():
+    client = make_client()
+
+    request = client.prepare_get_payment_status(payment_id="pay_xxxxxxxx")
+
+    assert request.method == "GET"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments/pay_xxxxxxxx"
+    assert request.operation == "get_payment_status"
+    assert request.json is None
+    assert request.real_money is False
+    assert request.http_call_executed is False
+
+
+def test_execute_prepared_request_is_blocked_in_this_milestone():
+    client = make_client()
+    request = client.prepare_get_payment_status(payment_id="pay_xxxxxxxx")
+
+    with pytest.raises(RuntimeError, match="HTTP execution is intentionally blocked"):
+        client.execute_prepared_request(request)
+
+    assert request.http_call_executed is False
+
+
+def test_prepared_request_safe_summary_does_not_include_secrets():
+    client = make_client()
+    request = client.prepare_get_payment_status(payment_id="pay_xxxxxxxx")
+
+    summary = request.safe_summary()
+
+    assert summary["http_call_executed"] is False
+    assert summary["real_money"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)

--- a/docs/WALLET_ASAAS_SANDBOX_CLIENT_SKELETON_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_CLIENT_SKELETON_V1.md
@@ -1,0 +1,156 @@
+# Aurea Gold / dils-wallet — Asaas Sandbox Client Skeleton V1
+
+Marco planejado: v0.2.41-wallet-asaas-sandbox-client-skeleton
+
+Status: esqueleto seguro do cliente Asaas Sandbox.
+
+Este marco cria o esqueleto do cliente Asaas Sandbox sem executar chamadas HTTP.
+
+Nao ha Pix real neste marco.
+
+Nao ha saldo real neste marco.
+
+Nao ha producao neste marco.
+
+Nao ha API Key real, token real ou Wallet ID real no Git.
+
+## 1. Objetivo
+
+Criar uma camada inicial para preparar requisicoes do fluxo Asaas Sandbox, usando as guardas de seguranca criadas no marco anterior.
+
+O objetivo deste marco e organizar o cliente tecnico antes de qualquer chamada real para o Sandbox.
+
+## 2. Arquivos criados
+
+Arquivos criados:
+
+- backend/app/partner/asaas_client.py
+- backend/tests/test_asaas_client_skeleton.py
+- docs/WALLET_ASAAS_SANDBOX_CLIENT_SKELETON_V1.md
+
+## 3. Relacao com o marco anterior
+
+Este marco depende das guardas criadas em:
+
+v0.2.40-wallet-asaas-sandbox-config-guards
+
+O cliente Asaas Sandbox usa:
+
+- AsaasSandboxConfig
+- load_asaas_sandbox_config
+
+Assim, qualquer uso sem configuracao segura deve falhar antes de preparar integracao real.
+
+## 4. O que o cliente prepara
+
+O cliente cria metadados seguros para os seguintes fluxos:
+
+- criar cliente pagador Sandbox;
+- criar cobranca Pix Sandbox;
+- obter QR Code Pix Sandbox;
+- consultar status de pagamento Sandbox.
+
+Endpoints preparados:
+
+- POST /v3/customers
+- POST /v3/payments
+- GET /v3/payments/{id}/pixQrCode
+- GET /v3/payments/{id}
+
+## 5. Sem chamada HTTP
+
+Este marco nao executa HTTP.
+
+O metodo execute_prepared_request bloqueia execucao e levanta erro intencional.
+
+A estrutura AsaasPreparedRequest registra:
+
+- method;
+- url;
+- operation;
+- json;
+- headers_configured;
+- real_money=false;
+- http_call_executed=false.
+
+## 6. Seguranca
+
+O cliente foi criado com as seguintes regras:
+
+- nao chama API do Asaas;
+- nao cria cobranca real;
+- nao cria cliente real;
+- nao consulta QR Code real;
+- nao consulta status real;
+- nao movimenta dinheiro;
+- nao libera saldo;
+- nao gera comprovante real;
+- nao loga API Key;
+- nao loga token de webhook.
+
+## 7. Testes adicionados
+
+Teste criado:
+
+- backend/tests/test_asaas_client_skeleton.py
+
+Cenarios cobertos:
+
+- prepara criacao de cliente Sandbox sem chamada HTTP;
+- prepara cobranca Pix Sandbox sem chamada HTTP;
+- prepara consulta de QR Code Pix sem chamada HTTP;
+- prepara consulta de status sem chamada HTTP;
+- bloqueia execucao HTTP neste marco;
+- safe_summary nao expoe API Key;
+- safe_summary nao expoe webhook token.
+
+## 8. Validacao local
+
+Comando executado:
+
+pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+17 passed
+
+## 9. Fora de escopo
+
+Nao faz parte deste marco:
+
+- chamada real ao Asaas Sandbox;
+- chamada real ao Asaas producao;
+- criacao real de cliente;
+- criacao real de cobranca Pix;
+- confirmacao real de pagamento;
+- webhook real;
+- conciliacao real;
+- saldo real;
+- Pix real;
+- subconta real;
+- split real;
+- transferencia real.
+
+## 10. Criterios de sucesso
+
+Este marco e considerado concluido quando:
+
+- o cliente skeleton estiver criado;
+- os testes passarem;
+- o cliente nao executar HTTP;
+- git diff --check passar;
+- o PR passar nos checks;
+- o PR for mergeado;
+- a tag oficial for criada.
+
+Tag esperada:
+
+v0.2.41-wallet-asaas-sandbox-client-skeleton
+
+## 11. Proximo marco provavel
+
+Proximo marco provavel:
+
+v0.2.42-wallet-asaas-sandbox-customer-dry-run
+
+Esse proximo marco pode preparar um dry-run mais explicito para cliente pagador Sandbox, ainda sem expor segredo e sem dinheiro real.


### PR DESCRIPTION
## Resumo
- adiciona o esqueleto seguro do cliente Asaas Sandbox
- prepara metadados para criar cliente, criar cobranca Pix, obter QR Code Pix e consultar status
- usa a configuracao segura criada no marco v0.2.40
- mantem execucao HTTP bloqueada neste marco
- adiciona testes automatizados do client skeleton
- documenta o marco v0.2.41

## Seguranca
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- sem Pix real
- sem saldo real
- sem producao
- sem chamada HTTP executada

## Validacao local
- cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
- resultado: 17 passed

## Proximo marco provavel
v0.2.42-wallet-asaas-sandbox-customer-dry-run