### PR TITLE
feat(wallet): add Asaas sandbox customer dry run

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -34,6 +34,25 @@ class AsaasPreparedRequest:
         }
 
 
+@dataclass(frozen=True)
+class AsaasCustomerDryRunResult:
+    prepared_request: AsaasPreparedRequest
+    customer_reference: str = "dry-run-customer-sandbox"
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "customer_dry_run",
+            "customer_reference": self.customer_reference,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_review_before_any_sandbox_http_call",
+        }
+
+
 class AsaasSandboxClient:
     """
     Skeleton client for Asaas Sandbox.
@@ -99,6 +118,23 @@ class AsaasSandboxClient:
             operation="create_customer",
             json=payload,
         )
+
+    def dry_run_create_customer(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+    ) -> AsaasCustomerDryRunResult:
+        prepared_request = self.prepare_create_customer(
+            name=name,
+            cpf_cnpj=cpf_cnpj,
+            email=email,
+            mobile_phone=mobile_phone,
+        )
+
+        return AsaasCustomerDryRunResult(prepared_request=prepared_request)
 
     def prepare_create_pix_payment(
         self,

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -116,3 +116,53 @@ def test_prepared_request_safe_summary_does_not_include_secrets():
     assert summary["real_money"] is False
     assert "sandbox-api-key-for-test-only" not in repr(summary)
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
+def test_customer_dry_run_reuses_create_customer_request_without_http_call():
+    client = make_client()
+
+    dry_run = client.dry_run_create_customer(
+        name="Cliente Dry Run Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.dryrun@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = dry_run.prepared_request
+
+    assert dry_run.customer_reference == "dry-run-customer-sandbox"
+    assert dry_run.real_money is False
+    assert dry_run.http_call_executed is False
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Dry Run Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.dryrun@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_customer_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
+    client = make_client()
+
+    dry_run = client.dry_run_create_customer(
+        name="Cliente Dry Run Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.dryrun@example.com",
+        mobile_phone="11999999999",
+    )
+
+    summary = dry_run.safe_summary()
+
+    assert summary["operation"] == "customer_dry_run"
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)

--- a/docs/WALLET_ASAAS_SANDBOX_CUSTOMER_DRY_RUN_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_CUSTOMER_DRY_RUN_V1.md
@@ -1,0 +1,86 @@
+# Aurea Gold Wallet - Asaas Sandbox Customer Dry Run v1
+
+## Marco
+
+v0.2.42-wallet-asaas-sandbox-customer-dry-run
+
+## Status
+
+Este marco adiciona um dry-run seguro para criacao de cliente pagador no Asaas Sandbox.
+
+Ele nao executa chamada HTTP, nao cria cliente real, nao cria Pix real, nao movimenta saldo e nao usa producao.
+
+## Objetivo
+
+O objetivo e validar que o fluxo de criacao de cliente Sandbox pode ser preparado de forma segura antes de qualquer chamada externa real.
+
+Este marco depende das travas dos marcos v0.2.40 e v0.2.41.
+
+## Arquivos alterados
+
+- backend/app/partner/asaas_client.py
+- backend/tests/test_asaas_client_skeleton.py
+- docs/WALLET_ASAAS_SANDBOX_CUSTOMER_DRY_RUN_V1.md
+
+## O que foi adicionado
+
+- AsaasCustomerDryRunResult
+- dry_run_create_customer
+- testes para garantir que o dry-run nao executa HTTP
+- safe_summary mantendo os flags de seguranca
+
+## Request preparado
+
+O dry-run prepara um request para POST /customers.
+
+Campos preparados:
+
+- name
+- cpfCnpj
+- email
+- mobilePhone
+
+## Garantias de seguranca
+
+- nenhuma chamada HTTP e executada
+- nenhum cliente real e criado
+- nenhum Pix real e criado
+- nenhum saldo real e movimentado
+- producao continua bloqueada
+- real_money=false
+- http_call_executed=false
+- ready_for_http_execution=false
+- API Key real nao deve ser usada
+- webhook token real nao deve ser usado
+- Wallet ID real nao deve ser usado
+- safe_summary nao expoe segredos
+
+## Fora de escopo
+
+- chamada real para o Asaas Sandbox
+- chamada para producao
+- persistencia de cliente no banco
+- criacao real de cobranca Pix
+- QR Code Pix real
+- webhook real
+- conciliacao real
+- saldo real
+- BaaS real
+- subconta real
+- split real
+
+## Validacao local
+
+Comando:
+
+cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+19 passed
+
+## Proximo passo provavel
+
+v0.2.43-wallet-asaas-sandbox-payment-dry-run
+
+Esse proximo marco deve preparar o dry-run de uma cobranca Pix Sandbox, ainda sem chamada HTTP real e sem dinheiro real.


### PR DESCRIPTION
## Resumo
- adiciona dry-run seguro para criacao de cliente pagador no Asaas Sandbox
- reutiliza o skeleton do cliente Asaas criado no v0.2.41
- adiciona AsaasCustomerDryRunResult
- adiciona metodo dry_run_create_customer
- adiciona testes garantindo que o dry-run nao executa HTTP
- documenta o marco v0.2.42

## Seguranca
- sem chamada HTTP executada
- sem cliente real criado
- sem Pix real
- sem saldo real
- sem producao
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- real_money=false
- http_call_executed=false
- ready_for_http_execution=false

## Validacao local
- cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
- resultado: 19 passed

## Proximo marco provavel
v0.2.43-wallet-asaas-sandbox-payment-dry-run