### PR TITLE
feat(wallet): add Asaas sandbox payment dry run

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -53,6 +53,27 @@ class AsaasCustomerDryRunResult:
         }
 
 
+@dataclass(frozen=True)
+class AsaasPaymentDryRunResult:
+    prepared_request: AsaasPreparedRequest
+    payment_reference: str = "dry-run-pix-payment-sandbox"
+    billing_type: str = "PIX"
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "payment_dry_run",
+            "payment_reference": self.payment_reference,
+            "billing_type": self.billing_type,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_review_before_any_sandbox_http_call",
+        }
+
+
 class AsaasSandboxClient:
     """
     Skeleton client for Asaas Sandbox.
@@ -158,6 +179,23 @@ class AsaasSandboxClient:
             operation="create_pix_payment",
             json=payload,
         )
+
+    def dry_run_create_pix_payment(
+        self,
+        *,
+        customer_id: str,
+        value: Decimal,
+        due_date: str,
+        description: str,
+    ) -> AsaasPaymentDryRunResult:
+        prepared_request = self.prepare_create_pix_payment(
+            customer_id=customer_id,
+            value=value,
+            due_date=due_date,
+            description=description,
+        )
+
+        return AsaasPaymentDryRunResult(prepared_request=prepared_request)
 
     def prepare_get_pix_qr_code(self, *, payment_id: str) -> AsaasPreparedRequest:
         return self._prepare(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -166,3 +166,56 @@ def test_customer_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
     assert summary["prepared_request"]["http_call_executed"] is False
     assert "sandbox-api-key-for-test-only" not in repr(summary)
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
+def test_payment_dry_run_reuses_pix_payment_request_without_http_call():
+    client = make_client()
+
+    dry_run = client.dry_run_create_pix_payment(
+        customer_id="cus_dry_run_xxxxxxxx",
+        value=Decimal("75.50"),
+        due_date="2026-07-15",
+        description="Dry run cobranca Pix Sandbox Aurea Gold",
+    )
+
+    request = dry_run.prepared_request
+
+    assert dry_run.payment_reference == "dry-run-pix-payment-sandbox"
+    assert dry_run.billing_type == "PIX"
+    assert dry_run.real_money is False
+    assert dry_run.http_call_executed is False
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments"
+    assert request.operation == "create_pix_payment"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "customer": "cus_dry_run_xxxxxxxx",
+        "billingType": "PIX",
+        "value": 75.5,
+        "dueDate": "2026-07-15",
+        "description": "Dry run cobranca Pix Sandbox Aurea Gold",
+    }
+
+
+def test_payment_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
+    client = make_client()
+
+    dry_run = client.dry_run_create_pix_payment(
+        customer_id="cus_dry_run_xxxxxxxx",
+        value=Decimal("75.50"),
+        due_date="2026-07-15",
+        description="Dry run cobranca Pix Sandbox Aurea Gold",
+    )
+
+    summary = dry_run.safe_summary()
+
+    assert summary["operation"] == "payment_dry_run"
+    assert summary["billing_type"] == "PIX"
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "create_pix_payment"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)

--- a/docs/WALLET_ASAAS_SANDBOX_PAYMENT_DRY_RUN_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_PAYMENT_DRY_RUN_V1.md
@@ -1,0 +1,87 @@
+# Aurea Gold Wallet - Asaas Sandbox Payment Dry Run v1
+
+## Marco
+
+v0.2.43-wallet-asaas-sandbox-payment-dry-run
+
+## Status
+
+Este marco adiciona um dry-run seguro para preparacao de cobranca Pix no Asaas Sandbox.
+
+Ele nao executa chamada HTTP, nao cria cobranca Pix real, nao movimenta saldo e nao usa producao.
+
+## Objetivo
+
+O objetivo e validar que o fluxo de criacao de cobranca Pix Sandbox pode ser preparado de forma segura antes de qualquer chamada externa real.
+
+Este marco depende das travas e bases dos marcos v0.2.40, v0.2.41 e v0.2.42.
+
+## Arquivos alterados
+
+- backend/app/partner/asaas_client.py
+- backend/tests/test_asaas_client_skeleton.py
+- docs/WALLET_ASAAS_SANDBOX_PAYMENT_DRY_RUN_V1.md
+
+## O que foi adicionado
+
+- AsaasPaymentDryRunResult
+- dry_run_create_pix_payment
+- testes para garantir que o dry-run Pix nao executa HTTP
+- safe_summary mantendo os flags de seguranca
+
+## Request preparado
+
+O dry-run prepara um request para POST /payments.
+
+Campos preparados:
+
+- customer
+- billingType=PIX
+- value
+- dueDate
+- description
+
+## Garantias de seguranca
+
+- nenhuma chamada HTTP e executada
+- nenhuma cobranca Pix real e criada
+- nenhum QR Code Pix real e gerado
+- nenhum saldo real e movimentado
+- producao continua bloqueada
+- real_money=false
+- http_call_executed=false
+- ready_for_http_execution=false
+- API Key real nao deve ser usada
+- webhook token real nao deve ser usado
+- Wallet ID real nao deve ser usado
+- safe_summary nao expoe segredos
+
+## Fora de escopo
+
+- chamada real para o Asaas Sandbox
+- chamada para producao
+- criacao real de cobranca Pix
+- QR Code Pix real
+- consulta real de status
+- webhook real
+- conciliacao real
+- saldo real
+- BaaS real
+- subconta real
+- split real
+
+## Validacao local
+
+Comando:
+
+cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+21 passed
+
+## Proximo passo provavel
+
+v0.2.44-wallet-asaas-sandbox-pix-qr-code-dry-run
+
+Esse proximo marco deve preparar o dry-run de obtencao do QR Code Pix Sandbox, ainda sem chamada HTTP real e sem dinheiro real.


### PR DESCRIPTION
## Resumo
- adiciona dry-run seguro para cobranca Pix no Asaas Sandbox
- reutiliza o skeleton do cliente Asaas criado no v0.2.41
- reutiliza a base do dry-run de cliente criada no v0.2.42
- adiciona AsaasPaymentDryRunResult
- adiciona metodo dry_run_create_pix_payment
- adiciona testes garantindo que o dry-run Pix nao executa HTTP
- documenta o marco v0.2.43

## Seguranca
- sem chamada HTTP executada
- sem cobranca Pix real criada
- sem QR Code Pix real
- sem saldo real
- sem producao
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- real_money=false
- http_call_executed=false
- ready_for_http_execution=false

## Validacao local
- cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
- resultado: 21 passed

## Proximo marco provavel
v0.2.44-wallet-asaas-sandbox-pix-qr-code-dry-run