### PR TITLE
feat(wallet): add Asaas sandbox Pix QR Code dry run

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -74,6 +74,25 @@ class AsaasPaymentDryRunResult:
         }
 
 
+@dataclass(frozen=True)
+class AsaasPixQrCodeDryRunResult:
+    prepared_request: AsaasPreparedRequest
+    qr_code_reference: str = "dry-run-pix-qr-code-sandbox"
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "pix_qr_code_dry_run",
+            "qr_code_reference": self.qr_code_reference,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_review_before_any_sandbox_http_call",
+        }
+
+
 class AsaasSandboxClient:
     """
     Skeleton client for Asaas Sandbox.
@@ -203,6 +222,15 @@ class AsaasSandboxClient:
             path=f"/payments/{payment_id}/pixQrCode",
             operation="get_pix_qr_code",
         )
+
+    def dry_run_get_pix_qr_code(
+        self,
+        *,
+        payment_id: str,
+    ) -> AsaasPixQrCodeDryRunResult:
+        prepared_request = self.prepare_get_pix_qr_code(payment_id=payment_id)
+
+        return AsaasPixQrCodeDryRunResult(prepared_request=prepared_request)
 
     def prepare_get_payment_status(self, *, payment_id: str) -> AsaasPreparedRequest:
         return self._prepare(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -219,3 +219,38 @@ def test_payment_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
     assert summary["prepared_request"]["http_call_executed"] is False
     assert "sandbox-api-key-for-test-only" not in repr(summary)
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
+def test_pix_qr_code_dry_run_reuses_qr_code_request_without_http_call():
+    client = make_client()
+
+    dry_run = client.dry_run_get_pix_qr_code(payment_id="pay_dry_run_xxxxxxxx")
+
+    request = dry_run.prepared_request
+
+    assert dry_run.qr_code_reference == "dry-run-pix-qr-code-sandbox"
+    assert dry_run.real_money is False
+    assert dry_run.http_call_executed is False
+    assert request.method == "GET"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments/pay_dry_run_xxxxxxxx/pixQrCode"
+    assert request.operation == "get_pix_qr_code"
+    assert request.json is None
+    assert request.real_money is False
+    assert request.http_call_executed is False
+
+
+def test_pix_qr_code_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
+    client = make_client()
+
+    dry_run = client.dry_run_get_pix_qr_code(payment_id="pay_dry_run_xxxxxxxx")
+
+    summary = dry_run.safe_summary()
+
+    assert summary["operation"] == "pix_qr_code_dry_run"
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "get_pix_qr_code"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)

--- a/docs/WALLET_ASAAS_SANDBOX_PIX_QR_CODE_DRY_RUN_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_PIX_QR_CODE_DRY_RUN_V1.md
@@ -1,0 +1,83 @@
+# Aurea Gold Wallet - Asaas Sandbox Pix QR Code Dry Run v1
+
+## Marco
+
+v0.2.44-wallet-asaas-sandbox-pix-qr-code-dry-run
+
+## Status
+
+Este marco adiciona um dry-run seguro para preparacao da obtencao de QR Code Pix no Asaas Sandbox.
+
+Ele nao executa chamada HTTP, nao obtem QR Code Pix real, nao cria Pix real, nao movimenta saldo e nao usa producao.
+
+## Objetivo
+
+O objetivo e validar que o fluxo de obtencao de QR Code Pix Sandbox pode ser preparado de forma segura antes de qualquer chamada externa real.
+
+Este marco depende das travas e bases dos marcos v0.2.40, v0.2.41, v0.2.42 e v0.2.43.
+
+## Arquivos alterados
+
+- backend/app/partner/asaas_client.py
+- backend/tests/test_asaas_client_skeleton.py
+- docs/WALLET_ASAAS_SANDBOX_PIX_QR_CODE_DRY_RUN_V1.md
+
+## O que foi adicionado
+
+- AsaasPixQrCodeDryRunResult
+- dry_run_get_pix_qr_code
+- testes para garantir que o dry-run de QR Code Pix nao executa HTTP
+- safe_summary mantendo os flags de seguranca
+
+## Request preparado
+
+O dry-run prepara um request para GET /payments/{id}/pixQrCode.
+
+Campo esperado:
+
+- payment_id
+
+## Garantias de seguranca
+
+- nenhuma chamada HTTP e executada
+- nenhum QR Code Pix real e obtido
+- nenhuma cobranca Pix real e criada
+- nenhum saldo real e movimentado
+- producao continua bloqueada
+- real_money=false
+- http_call_executed=false
+- ready_for_http_execution=false
+- API Key real nao deve ser usada
+- webhook token real nao deve ser usado
+- Wallet ID real nao deve ser usado
+- safe_summary nao expoe segredos
+
+## Fora de escopo
+
+- chamada real para o Asaas Sandbox
+- chamada para producao
+- obtencao real de QR Code Pix
+- criacao real de cobranca Pix
+- consulta real de status
+- webhook real
+- conciliacao real
+- saldo real
+- BaaS real
+- subconta real
+- split real
+
+## Validacao local
+
+Comando:
+
+cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+23 passed
+
+## Proximo passo provavel
+
+v0.2.45-wallet-asaas-sandbox-payment-status-dry-run
+
+Esse proximo marco deve preparar o dry-run de consulta de status de pagamento Sandbox, ainda sem chamada HTTP real e sem dinheiro real.


### PR DESCRIPTION
## Resumo
- adiciona dry-run seguro para QR Code Pix no Asaas Sandbox
- reutiliza o skeleton do cliente Asaas criado no v0.2.41
- reutiliza a base dos dry-runs criados nos marcos v0.2.42 e v0.2.43
- adiciona AsaasPixQrCodeDryRunResult
- adiciona metodo dry_run_get_pix_qr_code
- adiciona testes garantindo que o dry-run de QR Code Pix nao executa HTTP
- documenta o marco v0.2.44

## Seguranca
- sem chamada HTTP executada
- sem QR Code Pix real obtido
- sem cobranca Pix real criada
- sem saldo real
- sem producao
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- real_money=false
- http_call_executed=false
- ready_for_http_execution=false

## Validacao local
- cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
- resultado: 23 passed

## Proximo marco provavel
v0.2.45-wallet-asaas-sandbox-payment-status-dry-run