### PR TITLE
feat(wallet): add Asaas sandbox payment status dry run

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -93,6 +93,25 @@ class AsaasPixQrCodeDryRunResult:
         }
 
 
+@dataclass(frozen=True)
+class AsaasPaymentStatusDryRunResult:
+    prepared_request: AsaasPreparedRequest
+    status_reference: str = "dry-run-payment-status-sandbox"
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "payment_status_dry_run",
+            "status_reference": self.status_reference,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_review_before_any_sandbox_http_call",
+        }
+
+
 class AsaasSandboxClient:
     """
     Skeleton client for Asaas Sandbox.
@@ -238,6 +257,15 @@ class AsaasSandboxClient:
             path=f"/payments/{payment_id}",
             operation="get_payment_status",
         )
+
+    def dry_run_get_payment_status(
+        self,
+        *,
+        payment_id: str,
+    ) -> AsaasPaymentStatusDryRunResult:
+        prepared_request = self.prepare_get_payment_status(payment_id=payment_id)
+
+        return AsaasPaymentStatusDryRunResult(prepared_request=prepared_request)
 
     def execute_prepared_request(self, request: AsaasPreparedRequest) -> None:
         raise RuntimeError(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -254,3 +254,38 @@ def test_pix_qr_code_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets()
     assert summary["prepared_request"]["http_call_executed"] is False
     assert "sandbox-api-key-for-test-only" not in repr(summary)
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
+def test_payment_status_dry_run_reuses_status_request_without_http_call():
+    client = make_client()
+
+    dry_run = client.dry_run_get_payment_status(payment_id="pay_dry_run_xxxxxxxx")
+
+    request = dry_run.prepared_request
+
+    assert dry_run.status_reference == "dry-run-payment-status-sandbox"
+    assert dry_run.real_money is False
+    assert dry_run.http_call_executed is False
+    assert request.method == "GET"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/payments/pay_dry_run_xxxxxxxx"
+    assert request.operation == "get_payment_status"
+    assert request.json is None
+    assert request.real_money is False
+    assert request.http_call_executed is False
+
+
+def test_payment_status_dry_run_safe_summary_keeps_http_blocked_and_hides_secrets():
+    client = make_client()
+
+    dry_run = client.dry_run_get_payment_status(payment_id="pay_dry_run_xxxxxxxx")
+
+    summary = dry_run.safe_summary()
+
+    assert summary["operation"] == "payment_status_dry_run"
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "get_payment_status"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)

--- a/docs/WALLET_ASAAS_SANDBOX_PAYMENT_STATUS_DRY_RUN_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_PAYMENT_STATUS_DRY_RUN_V1.md
@@ -1,0 +1,84 @@
+# Aurea Gold Wallet - Asaas Sandbox Payment Status Dry Run v1
+
+## Marco
+
+v0.2.45-wallet-asaas-sandbox-payment-status-dry-run
+
+## Status
+
+Este marco adiciona um dry-run seguro para preparacao da consulta de status de pagamento no Asaas Sandbox.
+
+Ele nao executa chamada HTTP, nao consulta status real, nao cria Pix real, nao movimenta saldo e nao usa producao.
+
+## Objetivo
+
+O objetivo e validar que o fluxo de consulta de status de pagamento Sandbox pode ser preparado de forma segura antes de qualquer chamada externa real.
+
+Este marco depende das travas e bases dos marcos v0.2.40, v0.2.41, v0.2.42, v0.2.43 e v0.2.44.
+
+## Arquivos alterados
+
+- backend/app/partner/asaas_client.py
+- backend/tests/test_asaas_client_skeleton.py
+- docs/WALLET_ASAAS_SANDBOX_PAYMENT_STATUS_DRY_RUN_V1.md
+
+## O que foi adicionado
+
+- AsaasPaymentStatusDryRunResult
+- dry_run_get_payment_status
+- testes para garantir que o dry-run de status nao executa HTTP
+- safe_summary mantendo os flags de seguranca
+
+## Request preparado
+
+O dry-run prepara um request para GET /payments/{id}.
+
+Campo esperado:
+
+- payment_id
+
+## Garantias de seguranca
+
+- nenhuma chamada HTTP e executada
+- nenhuma consulta real no Asaas e executada
+- nenhum status real e obtido
+- nenhuma cobranca Pix real e criada
+- nenhum saldo real e movimentado
+- producao continua bloqueada
+- real_money=false
+- http_call_executed=false
+- ready_for_http_execution=false
+- API Key real nao deve ser usada
+- webhook token real nao deve ser usado
+- Wallet ID real nao deve ser usado
+- safe_summary nao expoe segredos
+
+## Fora de escopo
+
+- chamada real para o Asaas Sandbox
+- chamada para producao
+- consulta real de status
+- obtencao real de QR Code Pix
+- criacao real de cobranca Pix
+- webhook real
+- conciliacao real
+- saldo real
+- BaaS real
+- subconta real
+- split real
+
+## Validacao local
+
+Comando:
+
+cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
+
+Resultado esperado:
+
+25 passed
+
+## Proximo passo provavel
+
+v0.2.46-wallet-asaas-sandbox-full-dry-run-flow
+
+Esse proximo marco deve preparar o fluxo dry-run completo cliente -> cobranca Pix -> QR Code -> status, ainda sem chamada HTTP real e sem dinheiro real.


### PR DESCRIPTION
## Resumo
- adiciona dry-run seguro para consulta de status de pagamento no Asaas Sandbox
- reutiliza o skeleton do cliente Asaas criado no v0.2.41
- reutiliza a base dos dry-runs criados nos marcos v0.2.42, v0.2.43 e v0.2.44
- adiciona AsaasPaymentStatusDryRunResult
- adiciona metodo dry_run_get_payment_status
- adiciona testes garantindo que o dry-run de status nao executa HTTP
- documenta o marco v0.2.45

## Seguranca
- sem chamada HTTP executada
- sem consulta real no Asaas
- sem status real obtido
- sem cobranca Pix real criada
- sem saldo real
- sem producao
- sem API Key real
- sem webhook token real
- sem Wallet ID real
- real_money=false
- http_call_executed=false
- ready_for_http_execution=false

## Validacao local
- cd backend && pytest tests/test_asaas_client_skeleton.py tests/test_asaas_config_guards.py -q
- resultado: 25 passed

## Proximo marco provavel
v0.2.46-wallet-asaas-sandbox-full-dry-run-flow