### PR TITLE
feat(wallet): add Asaas sandbox first HTTP call preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Aurea Gold is an active fintech product under structured development, focused on
 
 Developed by **Dilson Pereira**
 GitHub: [dilson123-tech](https://github.com/dilson123-tech)
+- v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — adds a local preflight validation before the first Asaas Sandbox HTTP call, keeping HTTP blocked, production blocked, real money disabled and secrets masked.

--- a/backend/app/partner/asaas_config.py
+++ b/backend/app/partner/asaas_config.py
@@ -8,6 +8,11 @@ from typing import Mapping
 ASAAS_SANDBOX_BASE_URL = "https://sandbox.asaas.com/api/v3"
 ASAAS_PRODUCTION_BASE_URL = "https://api.asaas.com/v3"
 
+ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE = (
+    "AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, "
+    "SEM PRODUCAO E SEM DINHEIRO REAL."
+)
+
 
 class AsaasConfigError(RuntimeError):
     """Raised when Asaas Sandbox safety guards reject the configuration."""
@@ -46,6 +51,31 @@ class AsaasSandboxConfig:
             "wallet_mode": self.wallet_mode,
             "wallet_partner_provider": self.wallet_partner_provider,
             "http_calls_allowed": False,
+        }
+
+
+@dataclass(frozen=True)
+class AsaasFirstHttpCallPreflightResult:
+    config: AsaasSandboxConfig
+    target_method: str = "POST"
+    target_path: str = "/customers"
+    target_operation: str = "create_customer"
+    manual_authorization_registered: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, object]:
+        return {
+            "operation": "first_http_call_preflight",
+            "target_method": self.target_method,
+            "target_path": self.target_path,
+            "target_operation": self.target_operation,
+            "environment": self.config.safe_summary(),
+            "manual_authorization_registered": self.manual_authorization_registered,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_review_before_any_sandbox_http_call",
         }
 
 
@@ -117,4 +147,27 @@ def load_asaas_sandbox_config(
         real_money_enabled=False,
         wallet_mode=wallet_mode,
         wallet_partner_provider=wallet_partner_provider,
+    )
+
+
+def run_asaas_first_http_call_preflight(
+    env: Mapping[str, str] | None = None,
+    *,
+    manual_authorization_phrase: str = "",
+) -> AsaasFirstHttpCallPreflightResult:
+    """
+    Validate local safety requirements before the first Asaas Sandbox HTTP call.
+
+    This function intentionally performs no HTTP calls.
+    It only validates local configuration and records whether the mandatory
+    manual authorization phrase was provided.
+    """
+    config = load_asaas_sandbox_config(env)
+    manual_authorization_registered = (
+        manual_authorization_phrase.strip() == ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+    )
+
+    return AsaasFirstHttpCallPreflightResult(
+        config=config,
+        manual_authorization_registered=manual_authorization_registered,
     )

--- a/backend/tests/test_asaas_config_guards.py
+++ b/backend/tests/test_asaas_config_guards.py
@@ -2,8 +2,10 @@ import pytest
 
 from app.partner.asaas_config import (
     ASAAS_SANDBOX_BASE_URL,
+    ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
     AsaasConfigError,
     load_asaas_sandbox_config,
+    run_asaas_first_http_call_preflight,
 )
 
 
@@ -84,3 +86,47 @@ def test_load_asaas_sandbox_config_normalizes_trailing_slash():
     config = load_asaas_sandbox_config(env)
 
     assert config.base_url == ASAAS_SANDBOX_BASE_URL
+
+
+def test_first_http_call_preflight_accepts_safe_env_without_executing_http():
+    preflight = run_asaas_first_http_call_preflight(VALID_ENV)
+
+    assert preflight.target_method == "POST"
+    assert preflight.target_path == "/customers"
+    assert preflight.target_operation == "create_customer"
+    assert preflight.manual_authorization_registered is False
+    assert preflight.real_money is False
+    assert preflight.http_call_executed is False
+
+
+def test_first_http_call_preflight_recognizes_manual_authorization_but_keeps_http_blocked():
+    preflight = run_asaas_first_http_call_preflight(
+        VALID_ENV,
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = preflight.safe_summary()
+
+    assert preflight.manual_authorization_registered is True
+    assert summary["operation"] == "first_http_call_preflight"
+    assert summary["target_method"] == "POST"
+    assert summary["target_path"] == "/customers"
+    assert summary["target_operation"] == "create_customer"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["environment"]["http_calls_allowed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
+def test_first_http_call_preflight_rejects_unsafe_env_before_any_http_call():
+    env = dict(VALID_ENV)
+    env["ASAAS_BASE_URL"] = "https://api.asaas.com/v3"
+
+    with pytest.raises(AsaasConfigError, match="Production Asaas base URL is blocked"):
+        run_asaas_first_http_call_preflight(
+            env,
+            manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+        )

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_HTTP_CALL_PREFLIGHT_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_HTTP_CALL_PREFLIGHT_V1.md
@@ -1,0 +1,87 @@
+# Aurea Gold Wallet — Asaas Sandbox First HTTP Call Preflight V1
+
+Milestone: v0.2.49-wallet-asaas-sandbox-first-http-call-preflight
+
+## Purpose
+
+This milestone adds a local preflight validation before the first real HTTP call to the Asaas Sandbox.
+
+The preflight confirms that the local environment is safe before any future external Sandbox call is manually executed.
+
+## Safety status
+
+This milestone does not execute HTTP.
+
+It does not send requests to Asaas, create a customer, create a Pix charge, retrieve a Pix QR Code, check a real payment status, use production, move real money, expose API keys, expose webhook tokens or expose Wallet IDs.
+
+## First HTTP call target
+
+The planned first external Sandbox call remains:
+
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Base URL: https://sandbox.asaas.com/api/v3
+- Environment: sandbox
+
+This target is safer than starting with Pix charge creation, Pix QR Code retrieval, payment status lookup, wallet movement, split, subaccount or production behavior.
+
+## Added code
+
+The milestone adds:
+
+- ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+- AsaasFirstHttpCallPreflightResult
+- run_asaas_first_http_call_preflight
+
+The preflight reuses the strict Asaas Sandbox configuration guards already present in load_asaas_sandbox_config.
+
+## Validated environment rules
+
+The preflight requires:
+
+- WALLET_MODE=partner
+- WALLET_PARTNER_PROVIDER=asaas
+- REAL_MONEY_ENABLED=false
+- ASAAS_ENV=sandbox
+- ASAAS_BASE_URL=https://sandbox.asaas.com/api/v3
+- ASAAS_API_KEY configured outside Git
+- ASAAS_WEBHOOK_TOKEN configured outside Git
+- production base URL blocked
+- placeholder secrets blocked
+
+## Manual authorization phrase
+
+Required phrase:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+The preflight can recognize whether this phrase was provided, but it still does not allow automatic HTTP execution.
+
+## Safe summary behavior
+
+The preflight safe summary reports the operation, target method, target path, target operation, safe environment summary, manual authorization status, real_money=false, http_call_executed=false, ready_for_http_execution=false and the next required step.
+
+The summary does not include API Key, webhook token, Wallet ID, headers, raw secrets or production credentials.
+
+## Tests added
+
+The test suite confirms that safe Sandbox environment is accepted, the first target is POST /customers, no HTTP is executed, real money remains disabled, manual authorization can be recognized, HTTP remains blocked after authorization recognition, production URL is rejected before any HTTP call and safe summary does not leak secrets.
+
+## Validation
+
+Validated locally with:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Result:
+
+30 passed
+
+## Out of scope
+
+This milestone does not implement a real HTTP transport, execute the first Sandbox call, create a real Asaas customer, create a Pix payment, retrieve a Pix QR Code, check payment status, enable production, enable real money, store secrets or print secrets.
+
+## Next likely milestone
+
+v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -120,3 +120,4 @@ The remaining gap to full market readiness is no longer centered on engineering,
 - presentation
 
 The transition from a technically solid system to a commercially compelling product is currently in progress.
+- v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — local preflight for the first future Asaas Sandbox HTTP call; still no HTTP execution, no production, no real money and no exposed secrets.


### PR DESCRIPTION
## Resumo
- adiciona o preflight local antes da primeira chamada HTTP real no Asaas Sandbox
- define o alvo seguro como POST /customers
- registra a frase obrigatoria de autorizacao manual
- valida ambiente Sandbox antes de qualquer chamada externa
- mantem HTTP bloqueado mesmo quando a frase manual e reconhecida
- atualiza README, product maturity e documentacao do marco

## Seguranca
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe webhook token
- nao expoe Wallet ID
- bloqueia URL de producao antes de qualquer chamada

## Validacao local
- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 30 passed
- pre-commit OK

## Proximo marco provavel
v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate