### PR TITLE
feat(wallet): add Asaas sandbox first customer HTTP client gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ Aurea Gold is an active fintech product under structured development, focused on
 Developed by **Dilson Pereira**
 GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — adds a local preflight validation before the first Asaas Sandbox HTTP call, keeping HTTP blocked, production blocked, real money disabled and secrets masked.
+- v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — adds a client-side gate for the first future Asaas Sandbox POST /customers call, keeping HTTP transport disabled, production blocked, real money disabled and secrets masked.

--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Literal
 
-from app.partner.asaas_config import AsaasSandboxConfig, load_asaas_sandbox_config
+from app.partner.asaas_config import (
+    ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    AsaasSandboxConfig,
+    load_asaas_sandbox_config,
+)
 
 
 AsaasHttpMethod = Literal["GET", "POST"]
@@ -50,6 +54,29 @@ class AsaasCustomerDryRunResult:
             "http_call_executed": self.http_call_executed,
             "ready_for_http_execution": False,
             "next_step_required": "manual_review_before_any_sandbox_http_call",
+        }
+
+
+@dataclass(frozen=True)
+class AsaasFirstCustomerHttpClientGateResult:
+    prepared_request: AsaasPreparedRequest
+    customer_reference: str = "first-customer-http-client-gate-sandbox"
+    manual_authorization_registered: bool = False
+    http_transport_enabled: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "first_customer_http_client_gate",
+            "customer_reference": self.customer_reference,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "manual_authorization_registered": self.manual_authorization_registered,
+            "http_transport_enabled": self.http_transport_enabled,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_transport_review_before_explicit_sandbox_execution",
         }
 
 
@@ -225,6 +252,31 @@ class AsaasSandboxClient:
         )
 
         return AsaasCustomerDryRunResult(prepared_request=prepared_request)
+
+    def gate_first_customer_http_call(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasFirstCustomerHttpClientGateResult:
+        prepared_request = self.prepare_create_customer(
+            name=name,
+            cpf_cnpj=cpf_cnpj,
+            email=email,
+            mobile_phone=mobile_phone,
+        )
+        manual_authorization_registered = (
+            manual_authorization_phrase.strip()
+            == ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+        )
+
+        return AsaasFirstCustomerHttpClientGateResult(
+            prepared_request=prepared_request,
+            manual_authorization_registered=manual_authorization_registered,
+        )
 
     def prepare_create_pix_payment(
         self,

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -3,7 +3,11 @@ from decimal import Decimal
 import pytest
 
 from app.partner.asaas_client import AsaasSandboxClient
-from app.partner.asaas_config import ASAAS_SANDBOX_BASE_URL, AsaasSandboxConfig
+from app.partner.asaas_config import (
+    ASAAS_SANDBOX_BASE_URL,
+    ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    AsaasSandboxConfig,
+)
 
 
 TEST_CONFIG = AsaasSandboxConfig(
@@ -43,6 +47,63 @@ def test_prepare_create_customer_builds_sandbox_request_without_http_call():
         "email": "cliente.sandbox@example.com",
         "mobilePhone": "11999999999",
     }
+
+
+def test_first_customer_http_client_gate_prepares_customer_request_without_http_call():
+    client = make_client()
+
+    gate = client.gate_first_customer_http_call(
+        name="Cliente Gate Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.gate@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = gate.prepared_request
+
+    assert gate.customer_reference == "first-customer-http-client-gate-sandbox"
+    assert gate.manual_authorization_registered is False
+    assert gate.http_transport_enabled is False
+    assert gate.real_money is False
+    assert gate.http_call_executed is False
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Gate Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.gate@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_first_customer_http_client_gate_recognizes_manual_phrase_but_keeps_transport_off():
+    client = make_client()
+
+    gate = client.gate_first_customer_http_call(
+        name="Cliente Gate Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.gate@example.com",
+        mobile_phone="11999999999",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = gate.safe_summary()
+
+    assert gate.manual_authorization_registered is True
+    assert summary["operation"] == "first_customer_http_client_gate"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["http_transport_enabled"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
 
 
 def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_CLIENT_GATE_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_CLIENT_GATE_V1.md
@@ -1,0 +1,100 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Client Gate V1
+
+Milestone: v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate
+
+## Purpose
+
+This milestone adds a technical client gate for the first future Asaas Sandbox customer HTTP call.
+
+The gate prepares the exact customer request for POST /customers, recognizes the mandatory manual authorization phrase, and keeps the HTTP transport disabled.
+
+## Safety status
+
+This milestone does not execute HTTP.
+
+It does not send any request to Asaas, create a customer, create a Pix charge, retrieve a Pix QR Code, check payment status, use production, move real money, expose API Key, expose webhook token or expose Wallet ID.
+
+## First HTTP call target
+
+The planned first external Sandbox call remains:
+
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Base URL: https://sandbox.asaas.com/api/v3
+- Environment: sandbox
+
+## Added code
+
+The milestone adds:
+
+- AsaasFirstCustomerHttpClientGateResult
+- AsaasSandboxClient.gate_first_customer_http_call
+
+The gate reuses the existing prepare_create_customer request builder.
+
+## Gate behavior
+
+The gate:
+
+- prepares the customer request metadata;
+- checks whether the manual authorization phrase was provided;
+- keeps http_transport_enabled=false;
+- keeps ready_for_http_execution=false;
+- keeps http_call_executed=false;
+- keeps real_money=false;
+- returns only a safe summary.
+
+## Manual authorization phrase
+
+The gate recognizes the phrase:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+Recognizing the phrase does not execute HTTP and does not enable the HTTP transport.
+
+## Safe summary behavior
+
+The safe summary reports:
+
+- operation;
+- customer reference;
+- prepared request summary;
+- manual authorization status;
+- HTTP transport status;
+- real money status;
+- HTTP execution status;
+- next required step.
+
+The safe summary does not include API Key, webhook token, Wallet ID, headers or raw secrets.
+
+## Tests added
+
+The tests confirm that:
+
+- the gate prepares POST /customers;
+- the customer payload is preserved;
+- no HTTP call is executed;
+- real money remains disabled;
+- HTTP transport remains disabled;
+- the manual phrase can be recognized;
+- ready_for_http_execution remains false;
+- safe summary does not leak secrets.
+
+## Validation
+
+Validated locally with:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Result:
+
+32 passed
+
+## Out of scope
+
+This milestone does not implement a real HTTP transport, does not call Asaas, does not create a customer, does not create Pix, does not retrieve QR Code, does not consult status, does not enable production and does not enable real money.
+
+## Next likely milestone
+
+v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -121,3 +121,4 @@ The remaining gap to full market readiness is no longer centered on engineering,
 
 The transition from a technically solid system to a commercially compelling product is currently in progress.
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — local preflight for the first future Asaas Sandbox HTTP call; still no HTTP execution, no production, no real money and no exposed secrets.
+- v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — client gate for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.


### PR DESCRIPTION
## Resumo
- adiciona o gate tecnico do cliente para a primeira chamada futura POST /customers no Asaas Sandbox
- prepara a request de cliente usando o builder existente
- reconhece a frase obrigatoria de autorizacao manual
- mantem o transporte HTTP desligado
- atualiza README, product maturity e documentacao do marco

## Seguranca
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe webhook token
- nao expoe Wallet ID
- mantem http_transport_enabled=false
- mantem ready_for_http_execution=false
- mantem http_call_executed=false

## Validacao local
- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 32 passed
- pre-commit OK

## Proximo marco provavel
v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review