### PR TITLE
docs(wallet): add Asaas sandbox first customer HTTP transport review

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ Developed by **Dilson Pereira**
 GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — adds a local preflight validation before the first Asaas Sandbox HTTP call, keeping HTTP blocked, production blocked, real money disabled and secrets masked.
 - v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — adds a client-side gate for the first future Asaas Sandbox POST /customers call, keeping HTTP transport disabled, production blocked, real money disabled and secrets masked.
+- v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — reviews the safe design for the future Asaas Sandbox POST /customers HTTP transport, still without HTTP execution, production, real money or exposed secrets.

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_REVIEW_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_REVIEW_V1.md
@@ -1,0 +1,186 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Transport Review V1
+
+Milestone: v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review
+
+## Purpose
+
+This milestone reviews the safe design for the future HTTP transport that may execute the first controlled Asaas Sandbox customer call.
+
+It is a technical review milestone only.
+
+It does not implement a real HTTP transport and does not execute any external request.
+
+## Current target
+
+The first future external Sandbox call remains:
+
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Base URL: https://sandbox.asaas.com/api/v3
+- Environment: sandbox
+
+This remains the safest first target because it does not create a Pix charge, does not retrieve a Pix QR Code, does not check payment status, does not move money, does not use split, does not use subaccounts and does not use production.
+
+## Existing protection chain
+
+The current protection chain is:
+
+- strict Sandbox configuration guards;
+- blocked production URL;
+- real money disabled;
+- secrets configured outside Git;
+- manual execution gate;
+- first HTTP call runbook;
+- local preflight;
+- client-side customer HTTP gate;
+- HTTP transport still disabled.
+
+## Transport requirements before implementation
+
+Any future HTTP transport must keep these rules:
+
+- use Sandbox base URL only;
+- reject production URL before sending;
+- require WALLET_MODE=partner;
+- require WALLET_PARTNER_PROVIDER=asaas;
+- require REAL_MONEY_ENABLED=false;
+- require ASAAS_ENV=sandbox;
+- require the official Sandbox URL;
+- require local API Key without printing it;
+- never log raw headers;
+- never log access_token;
+- never log webhook token;
+- never log Wallet ID;
+- never log full sensitive responses;
+- never enable automatic execution;
+- never retry blindly;
+- never create Pix in this first customer step.
+
+## Required request shape
+
+The reviewed first request shape is:
+
+- method: POST;
+- path: /customers;
+- operation: create_customer;
+- body with fictitious customer data only;
+- header access_token sourced from local environment only;
+- no production credentials;
+- no real customer data;
+- no real CPF;
+- no real email;
+- no real phone;
+- no real bank data;
+- no Pix key.
+
+## Approved fictitious payload class
+
+The future payload may use only fictitious test data, such as:
+
+- name: Cliente Sandbox Aurea Gold;
+- cpfCnpj: fictitious test CPF only;
+- email: cliente.sandbox@example.com;
+- mobilePhone: fictitious test phone only.
+
+## Forbidden data
+
+The future request must not use:
+
+- real customer name;
+- real CPF or CNPJ;
+- real email;
+- real phone;
+- real bank data;
+- real Pix key;
+- production API Key;
+- webhook token in request body;
+- Wallet ID;
+- user personal data.
+
+## Response handling requirements
+
+A future transport must record only a safe result summary.
+
+Allowed result fields:
+
+- operation;
+- environment;
+- method;
+- path;
+- HTTP status code;
+- success or failure;
+- sanitized customer id, masked or omitted;
+- timestamp;
+- confirmation that no production call happened;
+- confirmation that no real money moved;
+- confirmation that no secrets were logged.
+
+Forbidden result fields:
+
+- API Key;
+- access_token header;
+- webhook token;
+- Wallet ID;
+- full raw response if sensitive;
+- full raw headers;
+- real customer data.
+
+## Failure behavior
+
+The future transport must stop immediately if:
+
+- production URL is detected;
+- real money flag is true;
+- environment is not sandbox;
+- provider is not asaas;
+- API Key is missing;
+- API Key looks like placeholder;
+- manual authorization is missing;
+- payload contains real-looking data;
+- request target is not POST /customers;
+- any Pix, QR Code, payment, split or subaccount operation is attempted.
+
+## Manual authorization requirement
+
+The mandatory phrase remains:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+This review does not execute anything even if the phrase exists.
+
+## Non-goals
+
+This milestone does not:
+
+- implement requests, httpx, aiohttp or urllib calls;
+- send a request to Asaas;
+- create a customer;
+- create Pix;
+- retrieve QR Code;
+- check payment status;
+- use production;
+- move money;
+- expose secrets.
+
+## Validation
+
+This is a documentation and transport review milestone.
+
+Validation must include:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Expected result:
+
+32 passed
+
+## Decision
+
+The project is ready for a future controlled implementation of a Sandbox-only customer HTTP transport, but not for automatic execution.
+
+The next implementation must still default to blocked execution and require explicit manual authorization.
+
+## Next likely milestone
+
+v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -122,3 +122,4 @@ The remaining gap to full market readiness is no longer centered on engineering,
 The transition from a technically solid system to a commercially compelling product is currently in progress.
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — local preflight for the first future Asaas Sandbox HTTP call; still no HTTP execution, no production, no real money and no exposed secrets.
 - v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — client gate for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.
+- v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — safe transport review for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.


### PR DESCRIPTION
## Resumo
- adiciona a revisao tecnica do transporte HTTP futuro para POST /customers no Asaas Sandbox
- documenta requisitos do transporte antes de qualquer implementacao real
- define shape seguro da request, payload ficticio permitido e dados proibidos
- documenta regras de response handling, falhas obrigatorias e requisitos de autorizacao manual
- corrige textos grudados em README/product maturity/documentacao anterior

## Seguranca
- nao implementa transporte HTTP real
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe webhook token
- nao expoe Wallet ID
- mantem execucao futura dependente de autorizacao manual

## Validacao local
- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 32 passed
- pre-commit OK

## Proximo marco provavel
v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton