### PR TITLE
feat(wallet): add Asaas sandbox first customer HTTP transport skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,5 @@ GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — adds a local preflight validation before the first Asaas Sandbox HTTP call, keeping HTTP blocked, production blocked, real money disabled and secrets masked.
 - v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — adds a client-side gate for the first future Asaas Sandbox POST /customers call, keeping HTTP transport disabled, production blocked, real money disabled and secrets masked.
 - v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — reviews the safe design for the future Asaas Sandbox POST /customers HTTP transport, still without HTTP execution, production, real money or exposed secrets.
+
+- v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: adds the first safe Asaas Sandbox customer HTTP transport skeleton for the future POST /customers call, still with no HTTP implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.

--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -81,6 +81,37 @@ class AsaasFirstCustomerHttpClientGateResult:
 
 
 @dataclass(frozen=True)
+class AsaasFirstCustomerHttpTransportSkeletonResult:
+    prepared_request: AsaasPreparedRequest
+    transport_reference: str = "first-customer-http-transport-skeleton-sandbox"
+    manual_authorization_registered: bool = False
+    access_token_header_configured: bool = False
+    timeout_seconds: int = 30
+    retry_enabled: bool = False
+    http_transport_implemented: bool = False
+    http_transport_enabled: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "first_customer_http_transport_skeleton",
+            "transport_reference": self.transport_reference,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "manual_authorization_registered": self.manual_authorization_registered,
+            "access_token_header_configured": self.access_token_header_configured,
+            "timeout_seconds": self.timeout_seconds,
+            "retry_enabled": self.retry_enabled,
+            "http_transport_implemented": self.http_transport_implemented,
+            "http_transport_enabled": self.http_transport_enabled,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_transport_implementation_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasPaymentDryRunResult:
     prepared_request: AsaasPreparedRequest
     payment_reference: str = "dry-run-pix-payment-sandbox"
@@ -276,6 +307,32 @@ class AsaasSandboxClient:
         return AsaasFirstCustomerHttpClientGateResult(
             prepared_request=prepared_request,
             manual_authorization_registered=manual_authorization_registered,
+        )
+
+    def build_first_customer_http_transport_skeleton(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasFirstCustomerHttpTransportSkeletonResult:
+        prepared_request = self.prepare_create_customer(
+            name=name,
+            cpf_cnpj=cpf_cnpj,
+            email=email,
+            mobile_phone=mobile_phone,
+        )
+        manual_authorization_registered = (
+            manual_authorization_phrase.strip()
+            == ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+        )
+
+        return AsaasFirstCustomerHttpTransportSkeletonResult(
+            prepared_request=prepared_request,
+            manual_authorization_registered=manual_authorization_registered,
+            access_token_header_configured=prepared_request.headers_configured,
         )
 
     def prepare_create_pix_payment(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -106,6 +106,72 @@ def test_first_customer_http_client_gate_recognizes_manual_phrase_but_keeps_tran
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
 
 
+def test_first_customer_http_transport_skeleton_is_built_without_http_execution():
+    client = make_client()
+
+    transport = client.build_first_customer_http_transport_skeleton(
+        name="Cliente Transport Skeleton Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.transport@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = transport.prepared_request
+
+    assert transport.transport_reference == (
+        "first-customer-http-transport-skeleton-sandbox"
+    )
+    assert transport.manual_authorization_registered is False
+    assert transport.access_token_header_configured is True
+    assert transport.timeout_seconds == 30
+    assert transport.retry_enabled is False
+    assert transport.http_transport_implemented is False
+    assert transport.http_transport_enabled is False
+    assert transport.real_money is False
+    assert transport.http_call_executed is False
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Transport Skeleton Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.transport@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_first_customer_http_transport_skeleton_safe_summary_hides_secrets():
+    client = make_client()
+
+    transport = client.build_first_customer_http_transport_skeleton(
+        name="Cliente Transport Skeleton Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.transport@example.com",
+        mobile_phone="11999999999",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = transport.safe_summary()
+
+    assert transport.manual_authorization_registered is True
+    assert summary["operation"] == "first_customer_http_transport_skeleton"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["access_token_header_configured"] is True
+    assert summary["retry_enabled"] is False
+    assert summary["http_transport_implemented"] is False
+    assert summary["http_transport_enabled"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
 def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
     client = make_client()
 

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_SKELETON_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_SKELETON_V1.md
@@ -1,0 +1,120 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Transport Skeleton V1
+
+Milestone: v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton
+
+## Purpose
+
+This milestone adds the first safe HTTP transport skeleton for the future controlled Asaas Sandbox customer call.
+
+The target remains:
+
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Base URL: https://sandbox.asaas.com/api/v3
+- Environment: sandbox
+
+This milestone does not execute HTTP and does not send any request to Asaas.
+
+## What changed
+
+The client now has a transport skeleton result for the first customer HTTP call.
+
+Added:
+
+- AsaasFirstCustomerHttpTransportSkeletonResult
+- build_first_customer_http_transport_skeleton
+- tests proving the transport skeleton remains blocked
+- tests proving the safe summary does not expose secrets
+
+## Safety posture
+
+The transport skeleton records intent and safety metadata only.
+
+It keeps:
+
+- http_transport_implemented: false
+- http_transport_enabled: false
+- retry_enabled: false
+- real_money: false
+- http_call_executed: false
+- ready_for_http_execution: false
+
+The access token header is only represented as configured or not configured.
+
+The API Key value is never exposed.
+
+## Manual authorization
+
+The mandatory phrase may be recognized:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+Even when the phrase is present, this milestone still does not execute HTTP.
+
+Manual authorization registered does not mean ready for HTTP execution.
+
+## Explicit non-goals
+
+This milestone does not:
+
+- import requests;
+- import httpx;
+- import aiohttp;
+- import urllib;
+- open any network connection;
+- send a request to Asaas;
+- create a real customer;
+- create a Pix charge;
+- retrieve a Pix QR Code;
+- check real payment status;
+- use production;
+- move real money;
+- expose API Key;
+- expose webhook token;
+- expose Wallet ID.
+
+## Safe result summary
+
+The safe summary may include:
+
+- operation;
+- transport reference;
+- prepared request summary;
+- manual authorization status;
+- access token header configured flag;
+- timeout seconds;
+- retry disabled flag;
+- HTTP transport implemented flag;
+- HTTP transport enabled flag;
+- real money flag;
+- HTTP call executed flag.
+
+The safe summary must not include:
+
+- API Key value;
+- access_token value;
+- webhook token value;
+- Wallet ID;
+- raw headers;
+- raw sensitive response.
+
+## Validation
+
+Validation command:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Expected result:
+
+34 passed
+
+## Decision
+
+The project now has a safe skeleton for the future HTTP transport, but the transport is still not implemented and not enabled.
+
+The next step may be a stricter implementation review or a blocked transport adapter, still without executing a real Asaas request by default.
+
+## Next likely milestone
+
+v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -123,3 +123,5 @@ The transition from a technically solid system to a commercially compelling prod
 - v0.2.49-wallet-asaas-sandbox-first-http-call-preflight — local preflight for the first future Asaas Sandbox HTTP call; still no HTTP execution, no production, no real money and no exposed secrets.
 - v0.2.50-wallet-asaas-sandbox-first-customer-http-client-gate — client gate for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.
 - v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — safe transport review for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.
+
+- v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: safe transport skeleton for the future first Asaas Sandbox POST /customers call, keeping HTTP transport not implemented, execution disabled, production blocked, real money disabled and secrets hidden.


### PR DESCRIPTION
## Resumo
- adiciona o primeiro skeleton seguro do transporte HTTP futuro para POST /customers no Asaas Sandbox
- adiciona AsaasFirstCustomerHttpTransportSkeletonResult
- adiciona build_first_customer_http_transport_skeleton
- registra metadados seguros do transporte sem executar chamada externa
- adiciona testes garantindo que o transporte permanece nao implementado, desligado e sem exposicao de segredos
- atualiza README, product maturity e documentacao do marco v0.2.52

## Seguranca
- nao implementa requests, httpx, aiohttp ou urllib
- nao abre conexao de rede
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe webhook token
- nao expoe Wallet ID
- mesmo com frase manual reconhecida, ready_for_http_execution continua false

## Validacao local
- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 34 passed
- pre-commit OK

## Proximo marco provavel
v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate