### PR TITLE
feat(wallet): add Asaas sandbox first customer HTTP transport adapter gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,5 @@ GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — reviews the safe design for the future Asaas Sandbox POST /customers HTTP transport, still without HTTP execution, production, real money or exposed secrets.
 
 - v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: adds the first safe Asaas Sandbox customer HTTP transport skeleton for the future POST /customers call, still with no HTTP implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.
+
+- v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: adds a blocked adapter gate for the future Asaas Sandbox POST /customers transport, still with no HTTP adapter implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.

--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -112,6 +112,43 @@ class AsaasFirstCustomerHttpTransportSkeletonResult:
 
 
 @dataclass(frozen=True)
+class AsaasFirstCustomerHttpTransportAdapterGateResult:
+    prepared_request: AsaasPreparedRequest
+    adapter_reference: str = "first-customer-http-transport-adapter-gate-sandbox"
+    adapter_name: str = "blocked_sandbox_manual_http_adapter"
+    manual_authorization_registered: bool = False
+    access_token_header_configured: bool = False
+    sandbox_only: bool = True
+    target_allowed: bool = True
+    adapter_implemented: bool = False
+    adapter_enabled: bool = False
+    can_send_http: bool = False
+    retry_enabled: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "first_customer_http_transport_adapter_gate",
+            "adapter_reference": self.adapter_reference,
+            "adapter_name": self.adapter_name,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "manual_authorization_registered": self.manual_authorization_registered,
+            "access_token_header_configured": self.access_token_header_configured,
+            "sandbox_only": self.sandbox_only,
+            "target_allowed": self.target_allowed,
+            "adapter_implemented": self.adapter_implemented,
+            "adapter_enabled": self.adapter_enabled,
+            "can_send_http": self.can_send_http,
+            "retry_enabled": self.retry_enabled,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_blocked_adapter_review_before_any_http_send",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasPaymentDryRunResult:
     prepared_request: AsaasPreparedRequest
     payment_reference: str = "dry-run-pix-payment-sandbox"
@@ -333,6 +370,38 @@ class AsaasSandboxClient:
             prepared_request=prepared_request,
             manual_authorization_registered=manual_authorization_registered,
             access_token_header_configured=prepared_request.headers_configured,
+        )
+
+    def gate_first_customer_http_transport_adapter(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasFirstCustomerHttpTransportAdapterGateResult:
+        prepared_request = self.prepare_create_customer(
+            name=name,
+            cpf_cnpj=cpf_cnpj,
+            email=email,
+            mobile_phone=mobile_phone,
+        )
+        manual_authorization_registered = (
+            manual_authorization_phrase.strip()
+            == ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+        )
+        target_allowed = (
+            prepared_request.method == "POST"
+            and prepared_request.url == f"{self.base_url}/customers"
+            and prepared_request.operation == "create_customer"
+        )
+
+        return AsaasFirstCustomerHttpTransportAdapterGateResult(
+            prepared_request=prepared_request,
+            manual_authorization_registered=manual_authorization_registered,
+            access_token_header_configured=prepared_request.headers_configured,
+            target_allowed=target_allowed,
         )
 
     def prepare_create_pix_payment(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -172,6 +172,78 @@ def test_first_customer_http_transport_skeleton_safe_summary_hides_secrets():
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
 
 
+def test_first_customer_http_transport_adapter_gate_stays_blocked():
+    client = make_client()
+
+    adapter = client.gate_first_customer_http_transport_adapter(
+        name="Cliente Adapter Gate Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.adapter@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = adapter.prepared_request
+
+    assert adapter.adapter_reference == (
+        "first-customer-http-transport-adapter-gate-sandbox"
+    )
+    assert adapter.adapter_name == "blocked_sandbox_manual_http_adapter"
+    assert adapter.manual_authorization_registered is False
+    assert adapter.access_token_header_configured is True
+    assert adapter.sandbox_only is True
+    assert adapter.target_allowed is True
+    assert adapter.adapter_implemented is False
+    assert adapter.adapter_enabled is False
+    assert adapter.can_send_http is False
+    assert adapter.retry_enabled is False
+    assert adapter.real_money is False
+    assert adapter.http_call_executed is False
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Adapter Gate Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.adapter@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_first_customer_http_transport_adapter_gate_recognizes_phrase_but_cannot_send():
+    client = make_client()
+
+    adapter = client.gate_first_customer_http_transport_adapter(
+        name="Cliente Adapter Gate Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.adapter@example.com",
+        mobile_phone="11999999999",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = adapter.safe_summary()
+
+    assert adapter.manual_authorization_registered is True
+    assert summary["operation"] == "first_customer_http_transport_adapter_gate"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["access_token_header_configured"] is True
+    assert summary["sandbox_only"] is True
+    assert summary["target_allowed"] is True
+    assert summary["adapter_implemented"] is False
+    assert summary["adapter_enabled"] is False
+    assert summary["can_send_http"] is False
+    assert summary["retry_enabled"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
 def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
     client = make_client()
 

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_ADAPTER_GATE_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_TRANSPORT_ADAPTER_GATE_V1.md
@@ -1,0 +1,123 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Transport Adapter Gate V1
+
+Milestone: v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate
+
+## Purpose
+
+This milestone adds a blocked adapter gate for the future controlled Asaas Sandbox customer HTTP transport.
+
+The target remains:
+
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Base URL: https://sandbox.asaas.com/api/v3
+- Environment: sandbox
+
+This milestone does not implement a real HTTP adapter and does not send any request to Asaas.
+
+## What changed
+
+Added:
+
+- AsaasFirstCustomerHttpTransportAdapterGateResult
+- gate_first_customer_http_transport_adapter
+- adapter safety metadata
+- tests proving the adapter gate remains blocked
+- tests proving the safe summary does not expose secrets
+
+## Adapter gate behavior
+
+The adapter gate validates the intended first customer target and records safety state.
+
+It keeps:
+
+- sandbox_only: true
+- target_allowed: true for POST /customers create_customer
+- adapter_implemented: false
+- adapter_enabled: false
+- can_send_http: false
+- retry_enabled: false
+- real_money: false
+- http_call_executed: false
+- ready_for_http_execution: false
+
+## Manual authorization
+
+The mandatory phrase may be recognized:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+Even when the phrase is recognized, the adapter cannot send HTTP.
+
+Manual authorization registered does not enable the adapter.
+
+## Explicit non-goals
+
+This milestone does not:
+
+- import requests;
+- import httpx;
+- import aiohttp;
+- import urllib;
+- implement a network adapter;
+- open a network connection;
+- execute HTTP;
+- send a request to Asaas;
+- create a real customer;
+- create a Pix charge;
+- retrieve a Pix QR Code;
+- check real payment status;
+- use production;
+- move real money;
+- expose API Key;
+- expose webhook token;
+- expose Wallet ID.
+
+## Safe result summary
+
+The safe summary may include:
+
+- operation;
+- adapter reference;
+- adapter name;
+- prepared request summary;
+- manual authorization status;
+- access token header configured flag;
+- sandbox-only flag;
+- target allowed flag;
+- adapter implemented flag;
+- adapter enabled flag;
+- can send HTTP flag;
+- retry disabled flag;
+- real money flag;
+- HTTP call executed flag.
+
+The safe summary must not include:
+
+- API Key value;
+- access_token value;
+- webhook token value;
+- Wallet ID;
+- raw headers;
+- raw sensitive response.
+
+## Validation
+
+Validation command:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Expected result:
+
+36 passed
+
+## Decision
+
+The project now has a blocked adapter gate for the future Asaas Sandbox POST /customers transport.
+
+The adapter is still not implemented, not enabled and cannot send HTTP.
+
+## Next likely milestone
+
+v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -125,3 +125,5 @@ The transition from a technically solid system to a commercially compelling prod
 - v0.2.51-wallet-asaas-sandbox-first-customer-http-transport-review — safe transport review for the first future Asaas Sandbox POST /customers call; still no HTTP execution, no production, no real money and no exposed secrets.
 
 - v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: safe transport skeleton for the future first Asaas Sandbox POST /customers call, keeping HTTP transport not implemented, execution disabled, production blocked, real money disabled and secrets hidden.
+
+- v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: blocked adapter gate for the future first Asaas Sandbox POST /customers transport, keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled and secrets hidden.


### PR DESCRIPTION
## Resumo
- adiciona um adapter gate bloqueado para o futuro transporte HTTP do POST /customers no Asaas Sandbox
- adiciona AsaasFirstCustomerHttpTransportAdapterGateResult
- adiciona gate_first_customer_http_transport_adapter
- valida o alvo permitido POST /customers create_customer
- registra metadados seguros do adapter sem implementar transporte real
- adiciona testes garantindo que o adapter permanece nao implementado, desligado e incapaz de enviar HTTP
- atualiza README, product maturity e documentacao do marco v0.2.53

## Seguranca
- nao implementa requests, httpx, aiohttp ou urllib
- nao implementa adapter de rede real
- nao abre conexao de rede
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe webhook token
- nao expoe Wallet ID
- mesmo com frase manual reconhecida, adapter_enabled e can_send_http continuam false

## Validacao local
- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 36 passed
- pre-commit OK

## Proximo marco provavel
v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract
