### PR TITLE
feat(wallet): add Asaas sandbox first customer HTTP blocked adapter contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,5 @@ GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: adds the first safe Asaas Sandbox customer HTTP transport skeleton for the future POST /customers call, still with no HTTP implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.
 
 - v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: adds a blocked adapter gate for the future Asaas Sandbox POST /customers transport, still with no HTTP adapter implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.
+
+- v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract: adds a blocked adapter contract for the future Asaas Sandbox POST /customers transport, defining request, safe response and sanitized error shapes while keeping no HTTP adapter implementation, no HTTP execution, no Asaas request, no production, no real money and no exposed secrets.

--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -149,6 +149,78 @@ class AsaasFirstCustomerHttpTransportAdapterGateResult:
 
 
 @dataclass(frozen=True)
+class AsaasFirstCustomerHttpBlockedAdapterContractResult:
+    prepared_request: AsaasPreparedRequest
+    contract_reference: str = "first-customer-http-blocked-adapter-contract-sandbox"
+    adapter_name: str = "blocked_sandbox_first_customer_http_adapter_contract"
+    request_contract: dict[str, Any] = field(
+        default_factory=lambda: {
+            "method": "POST",
+            "path": "/customers",
+            "operation": "create_customer",
+            "required_header_names": ["access_token"],
+            "sensitive_header_values_masked": True,
+            "required_json_fields": ["name", "cpfCnpj", "email", "mobilePhone"],
+        }
+    )
+    response_contract: dict[str, Any] = field(
+        default_factory=lambda: {
+            "expected_success_statuses": [200, 201],
+            "expected_safe_fields": ["id", "name", "cpfCnpj", "email", "mobilePhone"],
+            "raw_response_blocked": True,
+            "secret_values_allowed": False,
+        }
+    )
+    error_contract: dict[str, Any] = field(
+        default_factory=lambda: {
+            "sanitized_error_fields": [
+                "status_code",
+                "provider_error_code",
+                "safe_message",
+                "retryable",
+            ],
+            "raw_error_blocked": True,
+            "secret_values_allowed": False,
+        }
+    )
+    manual_authorization_registered: bool = False
+    access_token_header_configured: bool = False
+    sandbox_only: bool = True
+    target_allowed: bool = True
+    adapter_implemented: bool = False
+    adapter_enabled: bool = False
+    can_send_http: bool = False
+    network_call_allowed: bool = False
+    retry_enabled: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "first_customer_http_blocked_adapter_contract",
+            "contract_reference": self.contract_reference,
+            "adapter_name": self.adapter_name,
+            "prepared_request": self.prepared_request.safe_summary(),
+            "request_contract": self.request_contract,
+            "response_contract": self.response_contract,
+            "error_contract": self.error_contract,
+            "manual_authorization_registered": self.manual_authorization_registered,
+            "access_token_header_configured": self.access_token_header_configured,
+            "sandbox_only": self.sandbox_only,
+            "target_allowed": self.target_allowed,
+            "adapter_implemented": self.adapter_implemented,
+            "adapter_enabled": self.adapter_enabled,
+            "can_send_http": self.can_send_http,
+            "network_call_allowed": self.network_call_allowed,
+            "retry_enabled": self.retry_enabled,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_blocked_adapter_contract_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasPaymentDryRunResult:
     prepared_request: AsaasPreparedRequest
     payment_reference: str = "dry-run-pix-payment-sandbox"
@@ -402,6 +474,34 @@ class AsaasSandboxClient:
             manual_authorization_registered=manual_authorization_registered,
             access_token_header_configured=prepared_request.headers_configured,
             target_allowed=target_allowed,
+        )
+
+    def build_first_customer_http_blocked_adapter_contract(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasFirstCustomerHttpBlockedAdapterContractResult:
+        adapter_gate = self.gate_first_customer_http_transport_adapter(
+            name=name,
+            cpf_cnpj=cpf_cnpj,
+            email=email,
+            mobile_phone=mobile_phone,
+            manual_authorization_phrase=manual_authorization_phrase,
+        )
+
+        return AsaasFirstCustomerHttpBlockedAdapterContractResult(
+            prepared_request=adapter_gate.prepared_request,
+            manual_authorization_registered=(
+                adapter_gate.manual_authorization_registered
+            ),
+            access_token_header_configured=(
+                adapter_gate.access_token_header_configured
+            ),
+            target_allowed=adapter_gate.target_allowed,
         )
 
     def prepare_create_pix_payment(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -244,6 +244,99 @@ def test_first_customer_http_transport_adapter_gate_recognizes_phrase_but_cannot
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
 
 
+def test_first_customer_http_blocked_adapter_contract_stays_blocked():
+    client = make_client()
+
+    contract = client.build_first_customer_http_blocked_adapter_contract(
+        name="Cliente Blocked Adapter Contract Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.contract@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = contract.prepared_request
+
+    assert contract.contract_reference == (
+        "first-customer-http-blocked-adapter-contract-sandbox"
+    )
+    assert contract.adapter_name == (
+        "blocked_sandbox_first_customer_http_adapter_contract"
+    )
+    assert contract.manual_authorization_registered is False
+    assert contract.access_token_header_configured is True
+    assert contract.sandbox_only is True
+    assert contract.target_allowed is True
+    assert contract.adapter_implemented is False
+    assert contract.adapter_enabled is False
+    assert contract.can_send_http is False
+    assert contract.network_call_allowed is False
+    assert contract.retry_enabled is False
+    assert contract.real_money is False
+    assert contract.http_call_executed is False
+
+    assert contract.request_contract == {
+        "method": "POST",
+        "path": "/customers",
+        "operation": "create_customer",
+        "required_header_names": ["access_token"],
+        "sensitive_header_values_masked": True,
+        "required_json_fields": ["name", "cpfCnpj", "email", "mobilePhone"],
+    }
+    assert contract.response_contract["expected_success_statuses"] == [200, 201]
+    assert contract.response_contract["raw_response_blocked"] is True
+    assert contract.response_contract["secret_values_allowed"] is False
+    assert contract.error_contract["raw_error_blocked"] is True
+    assert contract.error_contract["secret_values_allowed"] is False
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Blocked Adapter Contract Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.contract@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_first_customer_http_blocked_adapter_contract_recognizes_phrase_but_cannot_send():
+    client = make_client()
+
+    contract = client.build_first_customer_http_blocked_adapter_contract(
+        name="Cliente Blocked Adapter Contract Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.contract@example.com",
+        mobile_phone="11999999999",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = contract.safe_summary()
+
+    assert contract.manual_authorization_registered is True
+    assert summary["operation"] == "first_customer_http_blocked_adapter_contract"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["access_token_header_configured"] is True
+    assert summary["sandbox_only"] is True
+    assert summary["target_allowed"] is True
+    assert summary["adapter_implemented"] is False
+    assert summary["adapter_enabled"] is False
+    assert summary["can_send_http"] is False
+    assert summary["network_call_allowed"] is False
+    assert summary["retry_enabled"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["request_contract"]["path"] == "/customers"
+    assert summary["response_contract"]["raw_response_blocked"] is True
+    assert summary["error_contract"]["raw_error_blocked"] is True
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+
 def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
     client = make_client()
 

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_BLOCKED_ADAPTER_CONTRACT_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_BLOCKED_ADAPTER_CONTRACT_V1.md
@@ -1,0 +1,149 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Blocked Adapter Contract V1
+
+Milestone: v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract
+
+## Purpose
+
+This milestone adds a blocked contract for the future Asaas Sandbox first customer HTTP adapter.
+
+The contract defines the expected request, safe response shape and sanitized error shape for the future POST /customers call.
+
+This milestone still does not implement a real HTTP adapter and does not send any request to Asaas.
+
+## Confirmed Asaas target
+
+The target remains based on the Asaas Sandbox guidance:
+
+- Base URL: https://sandbox.asaas.com/api/v3
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Authentication header name: access_token
+- Environment: sandbox
+
+## What changed
+
+Added:
+
+- AsaasFirstCustomerHttpBlockedAdapterContractResult
+- build_first_customer_http_blocked_adapter_contract
+- request contract for the future POST /customers adapter
+- safe response contract
+- sanitized error contract
+- tests proving the contract remains blocked
+- tests proving manual authorization does not enable HTTP
+- tests proving the safe summary does not expose secrets
+
+## Request contract
+
+The request contract defines:
+
+- method: POST
+- path: /customers
+- operation: create_customer
+- required header names: access_token
+- sensitive header values masked: true
+- required JSON fields:
+  - name
+  - cpfCnpj
+  - email
+  - mobilePhone
+
+## Response contract
+
+The response contract defines:
+
+- expected success statuses:
+  - 200
+  - 201
+- expected safe fields:
+  - id
+  - name
+  - cpfCnpj
+  - email
+  - mobilePhone
+- raw response blocked: true
+- secret values allowed: false
+
+## Error contract
+
+The error contract defines only sanitized fields:
+
+- status_code
+- provider_error_code
+- safe_message
+- retryable
+
+The raw provider error remains blocked.
+
+Secret values are not allowed in errors.
+
+## Manual authorization
+
+The mandatory phrase may be recognized:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+Even when the phrase is recognized, the contract cannot send HTTP.
+
+Manual authorization registered does not enable the adapter.
+
+## Blocked adapter state
+
+The contract keeps:
+
+- sandbox_only: true
+- target_allowed: true for POST /customers create_customer
+- adapter_implemented: false
+- adapter_enabled: false
+- can_send_http: false
+- network_call_allowed: false
+- retry_enabled: false
+- real_money: false
+- http_call_executed: false
+- ready_for_http_execution: false
+
+## Explicit non-goals
+
+This milestone does not:
+
+- import requests;
+- import httpx;
+- import aiohttp;
+- import urllib;
+- implement a network adapter;
+- open a network connection;
+- execute HTTP;
+- send a request to Asaas;
+- create a real customer;
+- create a Pix charge;
+- retrieve a Pix QR Code;
+- check real payment status;
+- use production;
+- move real money;
+- expose API Key;
+- expose access_token value;
+- expose webhook token;
+- expose Wallet ID;
+- expose raw response;
+- expose raw provider error.
+
+## Validation
+
+Validation command:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Expected result:
+
+38 passed
+
+## Decision
+
+The project now has a blocked adapter contract for the future first Asaas Sandbox POST /customers call.
+
+The adapter is still not implemented, not enabled and cannot send HTTP.
+
+## Next likely milestone
+
+v0.2.55-wallet-asaas-sandbox-first-customer-http-response-sanitizer-contract

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -127,3 +127,5 @@ The transition from a technically solid system to a commercially compelling prod
 - v0.2.52-wallet-asaas-sandbox-first-customer-http-transport-skeleton: safe transport skeleton for the future first Asaas Sandbox POST /customers call, keeping HTTP transport not implemented, execution disabled, production blocked, real money disabled and secrets hidden.
 
 - v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: blocked adapter gate for the future first Asaas Sandbox POST /customers transport, keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled and secrets hidden.
+
+- v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract: blocked adapter contract for the future first Asaas Sandbox POST /customers transport, defining safe request, response and sanitized error shapes while keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled and secrets hidden.


### PR DESCRIPTION
## Resumo
- adiciona contrato bloqueado para o futuro adapter HTTP do primeiro POST /customers no Asaas Sandbox
- adiciona AsaasFirstCustomerHttpBlockedAdapterContractResult
- adiciona build_first_customer_http_blocked_adapter_contract
- define contrato de request para POST /customers
- define contrato de resposta segura
- define contrato de erro sanitizado
- adiciona testes garantindo que o contrato permanece bloqueado
- adiciona testes garantindo que autorizacao manual nao habilita HTTP
- atualiza README, product maturity e documentacao do marco v0.2.54

## Seguranca
- nao implementa requests, httpx, aiohttp ou urllib
- nao implementa adapter de rede real
- nao abre conexao de rede
- nao executa HTTP
- nao envia request ao Asaas
- nao cria cliente real
- nao cria cobranca Pix
- nao obtem QR Code Pix
- nao consulta status real
- nao usa producao
- nao movimenta dinheiro real
- nao expoe API Key
- nao expoe access_token
- nao expoe webhook token
- nao expoe Wallet ID
- nao expoe raw response
- nao expoe raw provider error
- mesmo com frase manual reconhecida, adapter_enabled, can_send_http, network_call_allowed e ready_for_http_execution continuam false

## Validacao local
- git diff --check
- grep de textos grudados sem ocorrencias
- grep de imports HTTP reais sem ocorrencias
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 38 passed
- pre-commit OK

## Proximo marco provavel
v0.2.55-wallet-asaas-sandbox-first-customer-http-response-sanitizer-contract
