### PR TITLE
feat(wallet): add Asaas sandbox first customer HTTP response sanitizer contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,5 @@ GitHub: [dilson123-tech](https://github.com/dilson123-tech)
 - v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: adds a blocked adapter gate for the future Asaas Sandbox POST /customers transport, still with no HTTP adapter implementation, no HTTP execution, no Asaas request, no real customer, no Pix, no production, no real money and no exposed secrets.
 
 - v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract: adds a blocked adapter contract for the future Asaas Sandbox POST /customers transport, defining request, safe response and sanitized error shapes while keeping no HTTP adapter implementation, no HTTP execution, no Asaas request, no production, no real money and no exposed secrets.
+
+- v0.2.55-wallet-asaas-sandbox-first-customer-http-response-sanitizer-contract: adds a response sanitizer contract for the future Asaas Sandbox POST /customers transport, defining safe success and error exposure rules while keeping no HTTP adapter implementation, no HTTP execution, no Asaas request, no production, no real money, no raw provider payload and no exposed secrets.

--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -221,6 +221,98 @@ class AsaasFirstCustomerHttpBlockedAdapterContractResult:
 
 
 @dataclass(frozen=True)
+class AsaasFirstCustomerHttpResponseSanitizerContractResult:
+    blocked_adapter_contract: AsaasFirstCustomerHttpBlockedAdapterContractResult
+    sanitizer_reference: str = (
+        "first-customer-http-response-sanitizer-contract-sandbox"
+    )
+    success_sanitizer_contract: dict[str, Any] = field(
+        default_factory=lambda: {
+            "allowed_fields": ["id", "name", "cpfCnpj", "email", "mobilePhone"],
+            "blocked_fields": [
+                "access_token",
+                "api_key",
+                "webhook_token",
+                "wallet_id",
+                "headers",
+                "raw",
+                "provider_raw",
+            ],
+            "raw_response_allowed": False,
+            "secret_values_allowed": False,
+            "safe_fields_only": True,
+        }
+    )
+    error_sanitizer_contract: dict[str, Any] = field(
+        default_factory=lambda: {
+            "allowed_fields": [
+                "status_code",
+                "provider_error_code",
+                "safe_message",
+                "retryable",
+            ],
+            "blocked_fields": [
+                "access_token",
+                "api_key",
+                "webhook_token",
+                "wallet_id",
+                "headers",
+                "raw",
+                "provider_raw",
+                "stacktrace",
+            ],
+            "raw_error_allowed": False,
+            "secret_values_allowed": False,
+            "safe_fields_only": True,
+        }
+    )
+    sanitizer_contract_defined: bool = True
+    sanitizer_implemented: bool = False
+    raw_response_retained: bool = False
+    raw_error_retained: bool = False
+    manual_authorization_registered: bool = False
+    sandbox_only: bool = True
+    adapter_implemented: bool = False
+    adapter_enabled: bool = False
+    can_send_http: bool = False
+    network_call_allowed: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+
+    @property
+    def prepared_request(self) -> AsaasPreparedRequest:
+        return self.blocked_adapter_contract.prepared_request
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "first_customer_http_response_sanitizer_contract",
+            "sanitizer_reference": self.sanitizer_reference,
+            "blocked_adapter_contract": (
+                self.blocked_adapter_contract.safe_summary()
+            ),
+            "prepared_request": self.prepared_request.safe_summary(),
+            "success_sanitizer_contract": self.success_sanitizer_contract,
+            "error_sanitizer_contract": self.error_sanitizer_contract,
+            "sanitizer_contract_defined": self.sanitizer_contract_defined,
+            "sanitizer_implemented": self.sanitizer_implemented,
+            "raw_response_retained": self.raw_response_retained,
+            "raw_error_retained": self.raw_error_retained,
+            "manual_authorization_registered": (
+                self.manual_authorization_registered
+            ),
+            "sandbox_only": self.sandbox_only,
+            "adapter_implemented": self.adapter_implemented,
+            "adapter_enabled": self.adapter_enabled,
+            "can_send_http": self.can_send_http,
+            "network_call_allowed": self.network_call_allowed,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "ready_for_http_execution": False,
+            "next_step_required": "manual_response_sanitizer_contract_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasPaymentDryRunResult:
     prepared_request: AsaasPreparedRequest
     payment_reference: str = "dry-run-pix-payment-sandbox"
@@ -502,6 +594,39 @@ class AsaasSandboxClient:
                 adapter_gate.access_token_header_configured
             ),
             target_allowed=adapter_gate.target_allowed,
+        )
+
+    def build_first_customer_http_response_sanitizer_contract(
+        self,
+        *,
+        name: str,
+        cpf_cnpj: str,
+        email: str,
+        mobile_phone: str,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasFirstCustomerHttpResponseSanitizerContractResult:
+        blocked_adapter_contract = (
+            self.build_first_customer_http_blocked_adapter_contract(
+                name=name,
+                cpf_cnpj=cpf_cnpj,
+                email=email,
+                mobile_phone=mobile_phone,
+                manual_authorization_phrase=manual_authorization_phrase,
+            )
+        )
+
+        return AsaasFirstCustomerHttpResponseSanitizerContractResult(
+            blocked_adapter_contract=blocked_adapter_contract,
+            manual_authorization_registered=(
+                blocked_adapter_contract.manual_authorization_registered
+            ),
+            sandbox_only=blocked_adapter_contract.sandbox_only,
+            adapter_implemented=blocked_adapter_contract.adapter_implemented,
+            adapter_enabled=blocked_adapter_contract.adapter_enabled,
+            can_send_http=blocked_adapter_contract.can_send_http,
+            network_call_allowed=blocked_adapter_contract.network_call_allowed,
+            real_money=blocked_adapter_contract.real_money,
+            http_call_executed=blocked_adapter_contract.http_call_executed,
         )
 
     def prepare_create_pix_payment(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -337,6 +337,123 @@ def test_first_customer_http_blocked_adapter_contract_recognizes_phrase_but_cann
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
 
 
+def test_first_customer_http_response_sanitizer_contract_stays_blocked():
+    client = make_client()
+
+    sanitizer = client.build_first_customer_http_response_sanitizer_contract(
+        name="Cliente Response Sanitizer Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.sanitizer@example.com",
+        mobile_phone="11999999999",
+    )
+
+    request = sanitizer.prepared_request
+    success_contract = sanitizer.success_sanitizer_contract
+    error_contract = sanitizer.error_sanitizer_contract
+
+    assert sanitizer.sanitizer_reference == (
+        "first-customer-http-response-sanitizer-contract-sandbox"
+    )
+    assert sanitizer.sanitizer_contract_defined is True
+    assert sanitizer.sanitizer_implemented is False
+    assert sanitizer.raw_response_retained is False
+    assert sanitizer.raw_error_retained is False
+    assert sanitizer.manual_authorization_registered is False
+    assert sanitizer.sandbox_only is True
+    assert sanitizer.adapter_implemented is False
+    assert sanitizer.adapter_enabled is False
+    assert sanitizer.can_send_http is False
+    assert sanitizer.network_call_allowed is False
+    assert sanitizer.real_money is False
+    assert sanitizer.http_call_executed is False
+
+    assert success_contract["allowed_fields"] == [
+        "id",
+        "name",
+        "cpfCnpj",
+        "email",
+        "mobilePhone",
+    ]
+    assert "access_token" in success_contract["blocked_fields"]
+    assert "api_key" in success_contract["blocked_fields"]
+    assert "webhook_token" in success_contract["blocked_fields"]
+    assert "wallet_id" in success_contract["blocked_fields"]
+    assert "raw" in success_contract["blocked_fields"]
+    assert success_contract["raw_response_allowed"] is False
+    assert success_contract["secret_values_allowed"] is False
+    assert success_contract["safe_fields_only"] is True
+
+    assert error_contract["allowed_fields"] == [
+        "status_code",
+        "provider_error_code",
+        "safe_message",
+        "retryable",
+    ]
+    assert "access_token" in error_contract["blocked_fields"]
+    assert "api_key" in error_contract["blocked_fields"]
+    assert "webhook_token" in error_contract["blocked_fields"]
+    assert "wallet_id" in error_contract["blocked_fields"]
+    assert "provider_raw" in error_contract["blocked_fields"]
+    assert "stacktrace" in error_contract["blocked_fields"]
+    assert error_contract["raw_error_allowed"] is False
+    assert error_contract["secret_values_allowed"] is False
+    assert error_contract["safe_fields_only"] is True
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/customers"
+    assert request.operation == "create_customer"
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json == {
+        "name": "Cliente Response Sanitizer Aurea Gold",
+        "cpfCnpj": "12345678909",
+        "email": "cliente.sanitizer@example.com",
+        "mobilePhone": "11999999999",
+    }
+
+
+def test_first_customer_http_response_sanitizer_contract_recognizes_phrase_but_cannot_send():
+    client = make_client()
+
+    sanitizer = client.build_first_customer_http_response_sanitizer_contract(
+        name="Cliente Response Sanitizer Aurea Gold",
+        cpf_cnpj="12345678909",
+        email="cliente.sanitizer@example.com",
+        mobile_phone="11999999999",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+
+    summary = sanitizer.safe_summary()
+
+    assert sanitizer.manual_authorization_registered is True
+    assert summary["operation"] == "first_customer_http_response_sanitizer_contract"
+    assert summary["manual_authorization_registered"] is True
+    assert summary["sanitizer_contract_defined"] is True
+    assert summary["sanitizer_implemented"] is False
+    assert summary["raw_response_retained"] is False
+    assert summary["raw_error_retained"] is False
+    assert summary["sandbox_only"] is True
+    assert summary["adapter_implemented"] is False
+    assert summary["adapter_enabled"] is False
+    assert summary["can_send_http"] is False
+    assert summary["network_call_allowed"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["success_sanitizer_contract"]["raw_response_allowed"] is False
+    assert summary["error_sanitizer_contract"]["raw_error_allowed"] is False
+    assert summary["blocked_adapter_contract"]["operation"] == (
+        "first_customer_http_blocked_adapter_contract"
+    )
+    assert summary["prepared_request"]["operation"] == "create_customer"
+    assert summary["prepared_request"]["http_call_executed"] is False
+    assert "sandbox-api-key-for-test-only" not in repr(summary)
+    assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+    assert "access_token" not in repr(summary["prepared_request"])
+    assert "provider_raw_response" not in repr(summary)
+    assert "provider_raw_error" not in repr(summary)
+
+
 def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
     client = make_client()
 

--- a/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_RESPONSE_SANITIZER_CONTRACT_V1.md
+++ b/docs/WALLET_ASAAS_SANDBOX_FIRST_CUSTOMER_HTTP_RESPONSE_SANITIZER_CONTRACT_V1.md
@@ -1,0 +1,160 @@
+# Aurea Gold Wallet — Asaas Sandbox First Customer HTTP Response Sanitizer Contract V1
+
+Milestone: v0.2.55-wallet-asaas-sandbox-first-customer-http-response-sanitizer-contract
+
+## Purpose
+
+This milestone adds a response sanitizer contract for the future first Asaas Sandbox POST /customers HTTP call.
+
+The sanitizer contract defines which fields may be safely exposed from a future provider response and which fields must always remain blocked.
+
+This milestone still does not implement a real HTTP adapter and does not send any request to Asaas.
+
+## Confirmed Asaas target
+
+The target remains:
+
+- Base URL: https://sandbox.asaas.com/api/v3
+- Method: POST
+- Path: /customers
+- Operation: create_customer
+- Authentication header name: access_token
+- Environment: sandbox
+
+## What changed
+
+Added:
+
+- AsaasFirstCustomerHttpResponseSanitizerContractResult
+- build_first_customer_http_response_sanitizer_contract
+- success response sanitizer contract
+- error response sanitizer contract
+- tests proving the sanitizer contract remains blocked
+- tests proving manual authorization does not enable HTTP
+- tests proving safe summaries do not expose secrets or raw provider payloads
+
+## Success sanitizer contract
+
+Allowed future response fields:
+
+- id
+- name
+- cpfCnpj
+- email
+- mobilePhone
+
+Blocked future response fields:
+
+- access_token
+- api_key
+- webhook_token
+- wallet_id
+- headers
+- raw
+- provider_raw
+
+The contract keeps:
+
+- raw_response_allowed: false
+- secret_values_allowed: false
+- safe_fields_only: true
+
+## Error sanitizer contract
+
+Allowed future error fields:
+
+- status_code
+- provider_error_code
+- safe_message
+- retryable
+
+Blocked future error fields:
+
+- access_token
+- api_key
+- webhook_token
+- wallet_id
+- headers
+- raw
+- provider_raw
+- stacktrace
+
+The contract keeps:
+
+- raw_error_allowed: false
+- secret_values_allowed: false
+- safe_fields_only: true
+
+## Manual authorization
+
+The mandatory phrase may be recognized:
+
+AUTORIZO EXECUTAR PRIMEIRA CHAMADA HTTP ASAAS SANDBOX, SEM PRODUCAO E SEM DINHEIRO REAL.
+
+Even when the phrase is recognized, the sanitizer contract cannot send HTTP.
+
+Manual authorization registered does not enable the adapter.
+
+## Blocked state
+
+The sanitizer contract keeps:
+
+- sanitizer_contract_defined: true
+- sanitizer_implemented: false
+- raw_response_retained: false
+- raw_error_retained: false
+- sandbox_only: true
+- adapter_implemented: false
+- adapter_enabled: false
+- can_send_http: false
+- network_call_allowed: false
+- real_money: false
+- http_call_executed: false
+- ready_for_http_execution: false
+
+## Explicit non-goals
+
+This milestone does not:
+
+- import requests;
+- import httpx;
+- import aiohttp;
+- import urllib;
+- implement a network adapter;
+- open a network connection;
+- execute HTTP;
+- send a request to Asaas;
+- create a real customer;
+- create a Pix charge;
+- retrieve a Pix QR Code;
+- check real payment status;
+- use production;
+- move real money;
+- expose API Key;
+- expose access_token value;
+- expose webhook token;
+- expose Wallet ID;
+- expose raw response;
+- expose raw provider error;
+- expose headers;
+- expose stacktrace.
+
+## Validation
+
+Validation command:
+
+cd backend && pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
+
+Expected result:
+
+40 passed
+
+## Decision
+
+The project now has a response sanitizer contract for the future first Asaas Sandbox POST /customers call.
+
+The adapter is still not implemented, not enabled and cannot send HTTP.
+
+## Next likely milestone
+
+v0.2.56-wallet-asaas-sandbox-first-customer-http-error-sanitizer-contract

--- a/docs/product-maturity.md
+++ b/docs/product-maturity.md
@@ -129,3 +129,5 @@ The transition from a technically solid system to a commercially compelling prod
 - v0.2.53-wallet-asaas-sandbox-first-customer-http-transport-adapter-gate: blocked adapter gate for the future first Asaas Sandbox POST /customers transport, keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled and secrets hidden.
 
 - v0.2.54-wallet-asaas-sandbox-first-customer-http-blocked-adapter-contract: blocked adapter contract for the future first Asaas Sandbox POST /customers transport, defining safe request, response and sanitized error shapes while keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled and secrets hidden.
+
+- v0.2.55-wallet-asaas-sandbox-first-customer-http-response-sanitizer-contract: response sanitizer contract for the future first Asaas Sandbox POST /customers transport, defining safe success and error exposure rules while keeping the adapter not implemented, disabled, unable to send HTTP, production blocked, real money disabled, raw provider payload blocked and secrets hidden.


### PR DESCRIPTION
## Summary

Adds the v0.2.55 Asaas Sandbox first customer HTTP response sanitizer contract.

This milestone defines safe success and error exposure rules for the future POST /customers transport while keeping HTTP execution blocked.

## Safety

- No HTTP adapter implementation
- No HTTP execution
- No Asaas request
- No production usage
- No real money
- No raw provider payload exposure
- No exposed API Key, access_token, webhook token or Wallet ID

## Validation

- git diff --check
- pytest tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q

Result: 40 passed