### PR TITLE
fix(wallet): add Asaas webhook panel URL fallback

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -57,3 +57,5 @@ placeholder.db
 /lan_links/
 /scripts/lan_qr_login.sh
 /scripts/which_api.sh
+.asaas-ngrok.pid
+.asaas-webhook-local.pid

--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -864,6 +864,8 @@ def _asaas_sandbox_webhook_idempotency_key(event_id: str) -> str:
     return f"asaas-sandbox-webhook:{digest}"
 
 
+@router.post("/api/v1/partners")
+@router.post("/api/v1/partners/")
 @router.post("/api/v1/partners/asaas/webhooks/sandbox")
 def handle_asaas_sandbox_webhook_receiver(
     payload: dict = Body(...),

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -155,3 +155,17 @@ def test_asaas_sandbox_webhook_ignores_non_payment_received_events_safely():
     assert response["event"]["ignored"] is True
     assert response["can_credit_balance"] is False
     assert "pay_created_must_not_leak" not in encoded
+
+
+
+def test_asaas_sandbox_webhook_registers_panel_fallback_routes():
+    paths = {
+        route.path
+        for route in wallet_routes.router.routes
+        if getattr(route, "endpoint", None)
+        is wallet_routes.handle_asaas_sandbox_webhook_receiver
+    }
+
+    assert "/api/v1/partners/asaas/webhooks/sandbox" in paths
+    assert "/api/v1/partners/" in paths
+    assert "/api/v1/partners" in paths


### PR DESCRIPTION
## Summary
- adds secure fallback routes for the Asaas Sandbox webhook receiver
- accepts POST /api/v1/partners and POST /api/v1/partners/
- keeps the original POST /api/v1/partners/asaas/webhooks/sandbox route
- adds regression coverage for all receiver routes
- ignores local Asaas test pid files

## Why
The Asaas Sandbox webhook panel delivered events to /api/v1/partners/ and previously received 404. The fallback keeps the same secure receiver logic while matching the panel delivery path observed in real Sandbox logs.

## Real Sandbox Validation
- Asaas Sandbox delivered a real webhook from IP 54.233.45.238
- backend returned POST /api/v1/partners/ HTTP/1.1 200 OK
- no production call
- no real money movement
- no real balance credit
- no real receipt generation

## Safety
- validates asaas-access-token through ASAAS_WEBHOOK_TOKEN
- uses Asaas Sandbox config guard
- keeps idempotency
- does not expose payment_id
- does not persist raw webhook payload
- does not credit balance
- does not generate real receipt
- does not mark real payment as paid

## Tests
- pytest tests/test_asaas_webhook_receiver.py tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 81 passed, 1 warning