### PR TITLE
feat(wallet): add Asaas sandbox webhook safe audit record

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -956,6 +956,41 @@ def handle_asaas_sandbox_webhook_receiver(
     payment_payload = payload.get("payment") if isinstance(payload.get("payment"), dict) else {}
     now = datetime.now(timezone.utc)
 
+    audit_record = {
+        "provider": "asaas",
+        "environment": "sandbox",
+        "source": "asaas_sandbox_webhook_receiver",
+        "audit_status": (
+            "asaas_sandbox_webhook_recorded"
+            if accepted
+            else "asaas_sandbox_webhook_ignored_recorded"
+        ),
+        "event_type": event_type,
+        "event_accepted": accepted,
+        "event_id_present": True,
+        "payment_object_present": bool(payment_payload),
+        "payment_id_present": bool(payment_payload.get("id")),
+        "payment_status": payment_payload.get("status"),
+        "billing_type": payment_payload.get("billingType"),
+        "received_at": now.isoformat(),
+        "storage": {
+            "source": "idempotency_keys",
+            "raw_payload_stored": False,
+            "raw_event_id_stored": False,
+            "raw_payment_id_stored": False,
+            "response_json_stored": True,
+        },
+        "idempotency": {
+            "key": idem_key,
+            "request_hash": request_hash,
+            "state": "stored",
+        },
+        "real_money_enabled": False,
+        "can_credit_balance": False,
+        "can_generate_real_receipt": False,
+        "can_mark_real_paid": False,
+    }
+
     response = {
         "ok": True,
         "service": "aurea-wallet",
@@ -981,6 +1016,7 @@ def handle_asaas_sandbox_webhook_receiver(
             "source": "asaas_sandbox",
             "real_money_enabled": False,
         },
+        "audit": audit_record,
         "idempotency": {
             "key": idem_key,
             "request_hash": request_hash,
@@ -1004,6 +1040,7 @@ def handle_asaas_sandbox_webhook_receiver(
         ],
     }
 
+    record.status_code = 200
     record.response_json = json.dumps(response, ensure_ascii=False, default=str)
     db.commit()
 

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -94,6 +94,19 @@ def test_asaas_sandbox_webhook_accepts_payment_received_without_exposing_sensiti
     assert "secret-token" not in encoded
     assert "pay_real_sandbox_must_not_leak" not in encoded
     assert "evt_test_unique_001" not in encoded
+    assert response["audit"]["provider"] == "asaas"
+    assert response["audit"]["environment"] == "sandbox"
+    assert response["audit"]["source"] == "asaas_sandbox_webhook_receiver"
+    assert response["audit"]["audit_status"] == "asaas_sandbox_webhook_recorded"
+    assert response["audit"]["event_accepted"] is True
+    assert response["audit"]["payment_id_present"] is True
+    assert response["audit"]["storage"]["raw_payload_stored"] is False
+    assert response["audit"]["storage"]["raw_event_id_stored"] is False
+    assert response["audit"]["storage"]["raw_payment_id_stored"] is False
+    assert response["audit"]["can_credit_balance"] is False
+    assert response["audit"]["can_generate_real_receipt"] is False
+    assert response["audit"]["can_mark_real_paid"] is False
+    assert next(iter(db.records.values())).status_code == 200
     assert db.committed is True
 
 
@@ -154,6 +167,9 @@ def test_asaas_sandbox_webhook_ignores_non_payment_received_events_safely():
     assert response["event"]["accepted"] is False
     assert response["event"]["ignored"] is True
     assert response["can_credit_balance"] is False
+    assert response["audit"]["audit_status"] == "asaas_sandbox_webhook_ignored_recorded"
+    assert response["audit"]["event_accepted"] is False
+    assert response["audit"]["storage"]["raw_payload_stored"] is False
     assert "pay_created_must_not_leak" not in encoded
 
 


### PR DESCRIPTION
## Summary
- adds a named safe audit record to the Asaas Sandbox webhook receiver response
- stores audit metadata in IdempotencyKey.response_json
- marks stored webhook responses with status_code=200
- records accepted and ignored Asaas Sandbox events safely
- reinforces tests for audit metadata and sensitive value protection

## Why
After validating the real Asaas Sandbox webhook delivery with 200 OK, this adds a safer internal audit trail for received webhook events without introducing a new database table yet.

## Safety
- does not store raw webhook payload
- does not store raw event_id
- does not store raw payment_id
- does not expose token
- does not credit real balance
- does not generate real receipt
- does not mark real payment as paid
- keeps real_money_enabled=false

## Scope
- Asaas Sandbox webhook receiver only
- no production calls
- no real money movement
- no migration
- no PSP/BaaS production behavior

## Tests
- pytest tests/test_asaas_webhook_receiver.py tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 81 passed, 1 warning