### PR TITLE
feat(wallet): add Asaas sandbox webhook audit history

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1521,6 +1521,155 @@ def get_wallet_pix_sandbox_audit_history(
     }
 
 
+def _list_asaas_sandbox_webhook_audit_events(
+    db: Session,
+    limit: int = 20,
+) -> list[dict]:
+    """
+    Lista auditoria segura de webhooks Asaas Sandbox.
+
+    Fase v0.2.74: histórico sem nova tabela.
+    Usa somente response_json seguro em IdempotencyKey.
+    Não consulta PSP real, não credita saldo e não emite comprovante real.
+    """
+    safe_limit = max(1, min(int(limit or 20), 100))
+
+    rows = (
+        db.query(IdempotencyKey)
+        .filter(IdempotencyKey.key.like("asaas-sandbox-webhook:%"))
+        .order_by(IdempotencyKey.created_at.desc())
+        .limit(safe_limit)
+        .all()
+    )
+
+    items: list[dict] = []
+
+    for row in rows:
+        raw_response = getattr(row, "response_json", None)
+        if not raw_response:
+            continue
+
+        try:
+            response = json.loads(raw_response)
+        except Exception:
+            continue
+
+        audit = response.get("audit") or {}
+        event = response.get("event") or {}
+        payment = response.get("payment") or {}
+        wallet_payload = response.get("wallet") or {}
+
+        if audit.get("provider") != "asaas":
+            continue
+
+        if audit.get("environment") != "sandbox":
+            continue
+
+        items.append({
+            "provider": "asaas",
+            "environment": "sandbox",
+            "source": audit.get("source") or "asaas_sandbox_webhook_receiver",
+            "event_type": audit.get("event_type") or event.get("event_type"),
+            "event_accepted": bool(audit.get("event_accepted", False)),
+            "payment_object_present": bool(
+                audit.get("payment_object_present", payment.get("object_present", False))
+            ),
+            "payment_id_present": bool(
+                audit.get("payment_id_present", payment.get("payment_id_present", False))
+            ),
+            "payment_status": audit.get("payment_status") or payment.get("status"),
+            "billing_type": audit.get("billing_type") or payment.get("billing_type"),
+            "received_at": audit.get("received_at") or event.get("received_at"),
+            "audit_status": audit.get("audit_status") or "asaas_sandbox_webhook_recorded",
+            "real_money_enabled": bool(
+                audit.get(
+                    "real_money_enabled",
+                    wallet_payload.get("real_money_enabled", False),
+                )
+            ),
+            "storage": {
+                "source": "idempotency_keys",
+                "raw_payload_stored": False,
+                "raw_event_id_stored": False,
+                "raw_payment_id_stored": False,
+                "response_json_stored": True,
+            },
+            "idempotency": {
+                "key": row.key,
+                "request_hash": row.request_hash,
+                "status_code": row.status_code,
+                "stored_at": row.created_at.isoformat() if row.created_at else None,
+            },
+            "can_credit_balance": False,
+            "can_generate_real_receipt": False,
+            "can_mark_real_paid": False,
+        })
+
+    return items
+
+
+@router.get("/api/v1/partners/asaas/webhooks/sandbox/audit-history")
+def get_asaas_sandbox_webhook_audit_history(
+    limit: int = 20,
+    current_user: User = Depends(require_customer),
+    db: Session = Depends(get_db),
+):
+    """
+    Lista histórico/auditoria segura de webhooks Asaas Sandbox.
+
+    Segurança:
+    - Não consulta transação real no Asaas.
+    - Não credita saldo real.
+    - Não gera comprovante financeiro real.
+    - Não marca pagamento real como confirmado.
+    - Não expõe token, event_id bruto nem payment_id bruto.
+    - Usa somente registros seguros já salvos por idempotência.
+    """
+    config = _asaas_sandbox_webhook_config()
+    safe_limit = max(1, min(int(limit or 20), 100))
+    items = _list_asaas_sandbox_webhook_audit_events(db, safe_limit)
+
+    return {
+        "ok": True,
+        "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
+        "history": {
+            "provider": "asaas",
+            "environment": config.env,
+            "source": "idempotency_keys",
+            "limit": safe_limit,
+            "total_returned": len(items),
+            "audit_status": "asaas_sandbox_webhooks_listed",
+        },
+        "wallet": {
+            "mode": WALLET_MODE,
+            "provider": "asaas",
+            "source": "asaas_sandbox",
+            "real_money_enabled": False,
+        },
+        "items": items,
+        "can_credit_balance": False,
+        "can_generate_real_receipt": False,
+        "can_mark_real_paid": False,
+        "notice": "Histórico Asaas Sandbox listado apenas para auditoria técnica. Não representa movimentação financeira real.",
+        "limitations": [
+            "Não credita saldo real.",
+            "Não confirma pagamento real em parceiro financeiro.",
+            "Não gera comprovante financeiro real.",
+            "Não expõe token.",
+            "Não expõe event_id bruto.",
+            "Não expõe payment_id bruto.",
+            "Não salva payload bruto.",
+        ],
+        "next_steps": [
+            "Exibir últimos webhooks Asaas Sandbox no painel técnico.",
+            "Adicionar filtros por event_type e audit_status em fase futura.",
+            "Persistir eventos em tabela própria de auditoria em fase futura.",
+            "Integrar histórico real somente após parceiro financeiro homologado.",
+        ],
+    }
+
+
 @router.get("/api/v1/wallet/balance")
 def get_balance(current_user: User = Depends(require_customer),
                 db: Session = Depends(get_db)):

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -17,13 +17,32 @@ class FakeQuery:
     def __init__(self, db):
         self.db = db
         self.key = None
+        self.row_limit = None
 
     def filter_by(self, **kwargs):
         self.key = kwargs.get("key")
         return self
 
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, value):
+        self.row_limit = int(value)
+        return self
+
     def first(self):
         return self.db.records.get(self.key)
+
+    def all(self):
+        rows = list(self.db.records.values())
+        rows = [row for row in rows if str(row.key).startswith("asaas-sandbox-webhook:")]
+        rows.sort(key=lambda row: str(getattr(row, "created_at", "") or ""), reverse=True)
+        if self.row_limit is not None:
+            rows = rows[: self.row_limit]
+        return rows
 
 
 class FakeDb:
@@ -69,7 +88,7 @@ def asaas_receiver_setup(monkeypatch):
     monkeypatch.setattr(
         wallet_routes,
         "load_asaas_sandbox_config",
-        lambda: SimpleNamespace(webhook_token="secret-token"),
+        lambda: SimpleNamespace(webhook_token="secret-token", env="sandbox"),
     )
 
 
@@ -185,3 +204,92 @@ def test_asaas_sandbox_webhook_registers_panel_fallback_routes():
     assert "/api/v1/partners/asaas/webhooks/sandbox" in paths
     assert "/api/v1/partners/" in paths
     assert "/api/v1/partners" in paths
+
+
+def test_asaas_sandbox_webhook_audit_history_lists_safe_records_without_sensitive_values():
+    db = FakeDb()
+
+    wallet_routes.handle_asaas_sandbox_webhook_receiver(
+        payload=_valid_payload(),
+        db=db,
+        asaas_access_token="secret-token",
+    )
+
+    response = wallet_routes.get_asaas_sandbox_webhook_audit_history(
+        limit=20,
+        current_user=SimpleNamespace(id=123),
+        db=db,
+    )
+
+    encoded = json.dumps(response, ensure_ascii=False, default=str)
+
+    assert response["ok"] is True
+    assert response["history"]["provider"] == "asaas"
+    assert response["history"]["environment"] == "sandbox"
+    assert response["history"]["source"] == "idempotency_keys"
+    assert response["history"]["total_returned"] == 1
+    assert response["wallet"]["provider"] == "asaas"
+    assert response["wallet"]["real_money_enabled"] is False
+    assert response["can_credit_balance"] is False
+    assert response["can_generate_real_receipt"] is False
+    assert response["can_mark_real_paid"] is False
+
+    item = response["items"][0]
+    assert item["provider"] == "asaas"
+    assert item["environment"] == "sandbox"
+    assert item["event_type"] == "PAYMENT_RECEIVED"
+    assert item["event_accepted"] is True
+    assert item["payment_id_present"] is True
+    assert item["audit_status"] == "asaas_sandbox_webhook_recorded"
+    assert item["storage"]["raw_payload_stored"] is False
+    assert item["storage"]["raw_event_id_stored"] is False
+    assert item["storage"]["raw_payment_id_stored"] is False
+    assert item["can_credit_balance"] is False
+    assert item["can_generate_real_receipt"] is False
+    assert item["can_mark_real_paid"] is False
+
+    assert "secret-token" not in encoded
+    assert "pay_real_sandbox_must_not_leak" not in encoded
+    assert "evt_test_unique_001" not in encoded
+
+
+def test_asaas_sandbox_webhook_audit_history_ignores_malformed_or_non_asaas_records():
+    db = FakeDb()
+
+    wallet_routes.handle_asaas_sandbox_webhook_receiver(
+        payload=_valid_payload(),
+        db=db,
+        asaas_access_token="secret-token",
+    )
+
+    good_key = next(iter(db.records))
+    good_record = db.records[good_key]
+
+    malformed = SimpleNamespace(
+        key="asaas-sandbox-webhook:malformed",
+        request_hash="bad",
+        status_code=200,
+        created_at=good_record.created_at,
+        response_json="{not-json",
+    )
+    non_asaas = SimpleNamespace(
+        key="asaas-sandbox-webhook:non-asaas",
+        request_hash="non-asaas",
+        status_code=200,
+        created_at=good_record.created_at,
+        response_json=json.dumps({
+            "audit": {
+                "provider": "other",
+                "environment": "sandbox",
+            }
+        }),
+    )
+
+    db.records[malformed.key] = malformed
+    db.records[non_asaas.key] = non_asaas
+
+    items = wallet_routes._list_asaas_sandbox_webhook_audit_events(db, limit=20)
+
+    assert len(items) == 1
+    assert items[0]["provider"] == "asaas"
+    assert items[0]["event_type"] == "PAYMENT_RECEIVED"


### PR DESCRIPTION
## Summary
- adds a safe audit history endpoint for Asaas Sandbox webhooks
- lists records from IdempotencyKey.response_json without creating a new table
- filters Asaas Sandbox webhook records by the asaas-sandbox-webhook idempotency prefix
- ignores malformed records and non-Asaas records
- adds regression tests for safe listing and sensitive value protection

## Endpoint
- GET /api/v1/partners/asaas/webhooks/sandbox/audit-history

## Safety
- does not query real Asaas transactions
- does not store or expose raw webhook payload
- does not expose token
- does not expose raw event_id
- does not expose raw payment_id
- does not credit real balance
- does not generate real receipt
- does not mark real payment as paid
- keeps real_money_enabled=false

## Scope
- Asaas Sandbox audit history only
- no production calls
- no real money movement
- no migration
- no PSP/BaaS production behavior

## Tests
- pytest tests/test_asaas_webhook_receiver.py tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 83 passed, 1 warning