### PR TITLE
feat(wallet): add Asaas sandbox webhook idempotent replay audit

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -920,7 +920,33 @@ def handle_asaas_sandbox_webhook_receiver(
         if existing.response_json:
             response = json.loads(existing.response_json)
             response["duplicated"] = True
-            response["idempotency"]["replayed"] = True
+            response.setdefault("idempotency", {})["replayed"] = True
+            response["idempotency"]["state"] = "replayed"
+            response["idempotency"]["replay_audit_status"] = (
+                "asaas_sandbox_webhook_idempotent_replay"
+            )
+
+            audit = response.setdefault("audit", {})
+            audit["replay"] = {
+                "replay_status": "asaas_sandbox_webhook_idempotent_replay",
+                "safe_replay": True,
+                "duplicated": True,
+                "idempotency_replayed": True,
+                "raw_payload_stored": False,
+                "raw_event_id_stored": False,
+                "raw_payment_id_stored": False,
+                "can_credit_balance": False,
+                "can_generate_real_receipt": False,
+                "can_mark_real_paid": False,
+                "notice": (
+                    "Evento Asaas Sandbox repetido reconhecido por idempotência. "
+                    "Nenhum saldo real, comprovante real ou pagamento real foi gerado."
+                ),
+            }
+
+            response["can_credit_balance"] = False
+            response["can_generate_real_receipt"] = False
+            response["can_mark_real_paid"] = False
             return response
 
         return {

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -156,9 +156,34 @@ def test_asaas_sandbox_webhook_is_idempotent_for_same_event():
         asaas_access_token="secret-token",
     )
 
+    encoded = json.dumps(second, ensure_ascii=False, default=str)
+
     assert first["duplicated"] is False
     assert second["duplicated"] is True
     assert second["idempotency"]["replayed"] is True
+    assert second["idempotency"]["state"] == "replayed"
+    assert (
+        second["idempotency"]["replay_audit_status"]
+        == "asaas_sandbox_webhook_idempotent_replay"
+    )
+    assert second["audit"]["replay"]["replay_status"] == (
+        "asaas_sandbox_webhook_idempotent_replay"
+    )
+    assert second["audit"]["replay"]["safe_replay"] is True
+    assert second["audit"]["replay"]["duplicated"] is True
+    assert second["audit"]["replay"]["idempotency_replayed"] is True
+    assert second["audit"]["replay"]["raw_payload_stored"] is False
+    assert second["audit"]["replay"]["raw_event_id_stored"] is False
+    assert second["audit"]["replay"]["raw_payment_id_stored"] is False
+    assert second["audit"]["replay"]["can_credit_balance"] is False
+    assert second["audit"]["replay"]["can_generate_real_receipt"] is False
+    assert second["audit"]["replay"]["can_mark_real_paid"] is False
+    assert second["can_credit_balance"] is False
+    assert second["can_generate_real_receipt"] is False
+    assert second["can_mark_real_paid"] is False
+    assert "secret-token" not in encoded
+    assert "pay_real_sandbox_must_not_leak" not in encoded
+    assert "evt_test_unique_001" not in encoded
     assert db.rolled_back is True
 
 


### PR DESCRIPTION
## Summary
- adds explicit safe replay audit metadata for repeated Asaas Sandbox webhook events
- marks idempotent replay responses with replayed=true and state=replayed
- adds replay_audit_status=asaas_sandbox_webhook_idempotent_replay
- keeps all replay responses safe with no real balance credit, no real receipt, and no real payment confirmation
- reinforces tests for replay safety and sensitive value protection

## Why
Asaas may retry webhook delivery. This makes repeated webhook handling auditable and explicit while preserving idempotency and preventing duplicate financial effects.

## Safety
- does not store or expose raw webhook payload
- does not expose token
- does not expose raw event_id
- does not expose raw payment_id
- does not credit real balance
- does not generate real receipt
- does not mark real payment as paid
- keeps real_money_enabled=false

## Scope
- Asaas Sandbox webhook receiver replay path only
- no production calls
- no real money movement
- no migration
- no PSP/BaaS production behavior

## Tests
- pytest tests/test_asaas_webhook_receiver.py tests/test_asaas_config_guards.py tests/test_asaas_client_skeleton.py -q
- 83 passed, 1 warning