### PR TITLE
feat(wallet): add Asaas sandbox subaccount structure guard

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -58,6 +58,67 @@ class AsaasCustomerDryRunResult:
 
 
 @dataclass(frozen=True)
+class AsaasSandboxSubaccountStructureGuardResult:
+    prepared_request: AsaasPreparedRequest
+    guard_reference: str = "subaccount-structure-guard-sandbox"
+    endpoint_path: str = "/accounts"
+    target_operation: str = "create_subaccount"
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    manual_authorization_required: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    sensitive_response_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    sensitive_request_fields: tuple[str, ...] = (
+        "cpfCnpj",
+        "email",
+        "phone",
+        "mobilePhone",
+        "address",
+    )
+    future_result_marker: str = "ASAAS_SANDBOX_SUBACCOUNT_STRUCTURE_VALIDATED"
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_structure_guard",
+            "guard_reference": self.guard_reference,
+            "endpoint_path": self.endpoint_path,
+            "target_operation": self.target_operation,
+            "prepared_request": {
+                "method": self.prepared_request.method,
+                "url": self.prepared_request.url,
+                "operation": self.prepared_request.operation,
+                "headers_configured": self.prepared_request.headers_configured,
+                "real_money": self.prepared_request.real_money,
+                "http_call_executed": self.prepared_request.http_call_executed,
+                "json_payload_stored": self.prepared_request.json is not None,
+                "raw": self.prepared_request.raw,
+            },
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "manual_authorization_required": self.manual_authorization_required,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "sensitive_response_fields": list(self.sensitive_response_fields),
+            "sensitive_request_fields": list(self.sensitive_request_fields),
+            "sensitive_response_fields_masked": True,
+            "sensitive_request_fields_masked": True,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": "manual_subaccount_payload_contract_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
     customer_reference: str = "first-customer-http-client-gate-sandbox"
@@ -1896,6 +1957,20 @@ class AsaasSandboxClient:
         )
 
         return AsaasCustomerDryRunResult(prepared_request=prepared_request)
+
+    def build_subaccount_structure_guard(
+        self,
+    ) -> AsaasSandboxSubaccountStructureGuardResult:
+        prepared_request = self._prepare(
+            method="POST",
+            path="/accounts",
+            operation="create_subaccount_structure_guard",
+            json=None,
+        )
+
+        return AsaasSandboxSubaccountStructureGuardResult(
+            prepared_request=prepared_request,
+        )
 
     def gate_first_customer_http_call(
         self,

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2604,3 +2604,64 @@ def test_full_pix_flow_dry_run_safe_summary_keeps_every_step_blocked():
     assert summary["payment_status"]["prepared_request"]["http_call_executed"] is False
     assert "sandbox-api-key-for-test-only" not in repr(summary)
     assert "sandbox-webhook-token-for-test-only" not in repr(summary)
+
+def test_subaccount_structure_guard_prepares_accounts_endpoint_without_http_call():
+    client = make_client()
+
+    guard = client.build_subaccount_structure_guard()
+    request = guard.prepared_request
+
+    assert guard.guard_reference == "subaccount-structure-guard-sandbox"
+    assert guard.endpoint_path == "/accounts"
+    assert guard.target_operation == "create_subaccount"
+    assert guard.sandbox_only is True
+    assert guard.production_blocked is True
+    assert guard.manual_authorization_required is True
+    assert guard.can_create_subaccount is False
+    assert guard.can_send_http is False
+    assert guard.real_money is False
+    assert guard.http_call_executed is False
+    assert guard.future_result_marker == "ASAAS_SANDBOX_SUBACCOUNT_STRUCTURE_VALIDATED"
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/accounts"
+    assert request.operation == "create_subaccount_structure_guard"
+    assert request.headers_configured is True
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.json is None
+    assert request.raw["sandbox"] is True
+    assert request.raw["provider"] == "asaas"
+    assert request.raw["http_execution_blocked"] is True
+
+
+def test_subaccount_structure_guard_safe_summary_hides_sensitive_values():
+    client = make_client()
+
+    guard = client.build_subaccount_structure_guard()
+    summary = guard.safe_summary()
+    rendered_summary = repr(summary)
+
+    assert summary["operation"] == "subaccount_structure_guard"
+    assert summary["prepared_request"]["operation"] == (
+        "create_subaccount_structure_guard"
+    )
+    assert summary["prepared_request"]["json_payload_stored"] is False
+    assert summary["sandbox_only"] is True
+    assert summary["production_blocked"] is True
+    assert summary["can_create_subaccount"] is False
+    assert summary["can_send_http"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+    assert summary["sensitive_response_fields_masked"] is True
+    assert summary["sensitive_request_fields_masked"] is True
+    assert "apiKey" in summary["sensitive_response_fields"]
+    assert "walletId" in summary["sensitive_response_fields"]
+    assert "onboardingUrl" in summary["sensitive_response_fields"]
+
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary


### PR DESCRIPTION
## Summary

Adds the Asaas Sandbox subaccount structure guard for v0.2.78.

## Scope

- adds AsaasSandboxSubaccountStructureGuardResult
- prepares the /accounts endpoint as blocked request metadata
- marks apiKey, walletId, id, onboardingUrl and request identity fields as sensitive
- keeps subaccount creation blocked
- keeps HTTP sending blocked
- keeps production blocked
- keeps real money disabled
- adds unit tests for the guard and safe summary

## Safety

- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure

## Validation

- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 85 passed, 1 warning