### PR TITLE
feat(wallet): add Asaas sandbox subaccount payload contract

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -119,6 +119,113 @@ class AsaasSandboxSubaccountStructureGuardResult:
 
 
 @dataclass(frozen=True)
+class AsaasSandboxSubaccountPayloadContractResult:
+    structure_guard: AsaasSandboxSubaccountStructureGuardResult
+    contract_reference: str = "subaccount-payload-contract-sandbox"
+    endpoint_path: str = "/accounts"
+    method: str = "POST"
+    target_operation: str = "create_subaccount"
+    request_body_build_enabled: bool = False
+    payload_values_stored: bool = False
+    raw_payload_stored: bool = False
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    manual_authorization_required: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    required_request_fields: tuple[str, ...] = (
+        "name",
+        "email",
+        "cpfCnpj",
+        "mobilePhone",
+        "incomeValue",
+        "address",
+        "addressNumber",
+        "province",
+        "postalCode",
+    )
+    optional_request_fields: tuple[str, ...] = (
+        "loginEmail",
+        "birthDate",
+        "companyType",
+        "phone",
+        "site",
+        "complement",
+    )
+    future_review_request_fields: tuple[str, ...] = (
+        "webhooks",
+    )
+    sensitive_request_fields: tuple[str, ...] = (
+        "cpfCnpj",
+        "email",
+        "loginEmail",
+        "phone",
+        "mobilePhone",
+        "address",
+        "addressNumber",
+        "complement",
+        "province",
+        "postalCode",
+        "birthDate",
+        "incomeValue",
+    )
+    prohibited_request_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+        "access_token",
+        "asaas-access-token",
+        "webhook_token",
+        "ASAAS_API_KEY",
+        "ASAAS_WEBHOOK_TOKEN",
+    )
+    sensitive_response_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    future_result_marker: str = "ASAAS_SANDBOX_SUBACCOUNT_PAYLOAD_CONTRACT_READY"
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_payload_contract",
+            "contract_reference": self.contract_reference,
+            "endpoint_path": self.endpoint_path,
+            "method": self.method,
+            "target_operation": self.target_operation,
+            "structure_guard": self.structure_guard.safe_summary(),
+            "request_body_build_enabled": self.request_body_build_enabled,
+            "payload_values_stored": self.payload_values_stored,
+            "raw_payload_stored": self.raw_payload_stored,
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "manual_authorization_required": self.manual_authorization_required,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "required_request_fields": list(self.required_request_fields),
+            "optional_request_fields": list(self.optional_request_fields),
+            "future_review_request_fields": list(
+                self.future_review_request_fields
+            ),
+            "sensitive_request_fields": list(self.sensitive_request_fields),
+            "prohibited_request_fields": list(self.prohibited_request_fields),
+            "sensitive_response_fields": list(self.sensitive_response_fields),
+            "field_names_only": True,
+            "field_values_masked": True,
+            "secret_values_allowed": False,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": "manual_subaccount_payload_builder_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
     customer_reference: str = "first-customer-http-client-gate-sandbox"
@@ -1970,6 +2077,15 @@ class AsaasSandboxClient:
 
         return AsaasSandboxSubaccountStructureGuardResult(
             prepared_request=prepared_request,
+        )
+
+    def build_subaccount_payload_contract(
+        self,
+    ) -> AsaasSandboxSubaccountPayloadContractResult:
+        structure_guard = self.build_subaccount_structure_guard()
+
+        return AsaasSandboxSubaccountPayloadContractResult(
+            structure_guard=structure_guard,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2665,3 +2665,97 @@ def test_subaccount_structure_guard_safe_summary_hides_sensitive_values():
     assert "subaccount-api-key-for-test-only" not in rendered_summary
     assert "wallet-id-for-test-only" not in rendered_summary
     assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+
+def test_subaccount_payload_contract_maps_required_fields_without_values():
+    client = make_client()
+
+    contract = client.build_subaccount_payload_contract()
+    summary = contract.safe_summary()
+
+    assert contract.contract_reference == "subaccount-payload-contract-sandbox"
+    assert contract.endpoint_path == "/accounts"
+    assert contract.method == "POST"
+    assert contract.target_operation == "create_subaccount"
+    assert contract.request_body_build_enabled is False
+    assert contract.payload_values_stored is False
+    assert contract.raw_payload_stored is False
+    assert contract.sandbox_only is True
+    assert contract.production_blocked is True
+    assert contract.manual_authorization_required is True
+    assert contract.can_create_subaccount is False
+    assert contract.can_send_http is False
+    assert contract.real_money is False
+    assert contract.http_call_executed is False
+    assert contract.future_result_marker == (
+        "ASAAS_SANDBOX_SUBACCOUNT_PAYLOAD_CONTRACT_READY"
+    )
+
+    assert summary["operation"] == "subaccount_payload_contract"
+    assert summary["field_names_only"] is True
+    assert summary["field_values_masked"] is True
+    assert summary["secret_values_allowed"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["structure_guard"]["operation"] == "subaccount_structure_guard"
+    assert summary["structure_guard"]["prepared_request"]["url"] == (
+        f"{ASAAS_SANDBOX_BASE_URL}/accounts"
+    )
+
+    for field_name in (
+        "name",
+        "email",
+        "cpfCnpj",
+        "mobilePhone",
+        "incomeValue",
+        "address",
+        "addressNumber",
+        "province",
+        "postalCode",
+    ):
+        assert field_name in summary["required_request_fields"]
+
+
+def test_subaccount_payload_contract_blocks_secret_and_response_only_fields():
+    client = make_client()
+
+    contract = client.build_subaccount_payload_contract()
+    summary = contract.safe_summary()
+    rendered_summary = repr(summary)
+
+    for field_name in (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+        "access_token",
+        "asaas-access-token",
+        "webhook_token",
+        "ASAAS_API_KEY",
+        "ASAAS_WEBHOOK_TOKEN",
+    ):
+        assert field_name in summary["prohibited_request_fields"]
+
+    for field_name in (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    ):
+        assert field_name in summary["sensitive_response_fields"]
+
+    for field_name in (
+        "cpfCnpj",
+        "email",
+        "loginEmail",
+        "mobilePhone",
+        "address",
+        "postalCode",
+        "incomeValue",
+    ):
+        assert field_name in summary["sensitive_request_fields"]
+
+    assert "webhooks" in summary["future_review_request_fields"]
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary


### PR DESCRIPTION
## Summary

Adds the Asaas Sandbox subaccount payload contract for v0.2.79.

## Scope

- adds AsaasSandboxSubaccountPayloadContractResult
- maps required subaccount request field names
- maps optional subaccount request field names
- marks webhooks as future review fields
- blocks response-only and secret fields from request usage
- keeps payload value storage disabled
- keeps raw payload storage disabled
- keeps request body build disabled
- keeps subaccount creation blocked
- keeps HTTP sending blocked
- adds unit tests for safe contract behavior

## Safety

- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure
- field names only, no sensitive field values

## Validation

- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 87 passed, 1 warning