### PR TITLE
feat(wallet): add Asaas sandbox subaccount payload builder guard

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -226,6 +226,76 @@ class AsaasSandboxSubaccountPayloadContractResult:
 
 
 @dataclass(frozen=True)
+class AsaasSandboxSubaccountPayloadBuilderGuardResult:
+    payload_contract: AsaasSandboxSubaccountPayloadContractResult
+    prepared_request: AsaasPreparedRequest
+    builder_reference: str = "subaccount-payload-builder-guard-sandbox"
+    endpoint_path: str = "/accounts"
+    method: str = "POST"
+    target_operation: str = "create_subaccount"
+    template_payload_built: bool = True
+    synthetic_payload_only: bool = True
+    payload_values_stored: bool = False
+    raw_payload_stored: bool = False
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    manual_authorization_required: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    future_result_marker: str = "ASAAS_SANDBOX_SUBACCOUNT_PAYLOAD_BUILDER_GUARD_READY"
+
+    def safe_summary(self) -> dict[str, Any]:
+        template = self.prepared_request.json or {}
+        prohibited_template_fields = sorted(
+            set(template).intersection(
+                set(self.payload_contract.prohibited_request_fields)
+            )
+        )
+
+        return {
+            "operation": "subaccount_payload_builder_guard",
+            "builder_reference": self.builder_reference,
+            "endpoint_path": self.endpoint_path,
+            "method": self.method,
+            "target_operation": self.target_operation,
+            "payload_contract": self.payload_contract.safe_summary(),
+            "prepared_request": {
+                "method": self.prepared_request.method,
+                "url": self.prepared_request.url,
+                "operation": self.prepared_request.operation,
+                "headers_configured": self.prepared_request.headers_configured,
+                "real_money": self.prepared_request.real_money,
+                "http_call_executed": self.prepared_request.http_call_executed,
+                "json_payload_template_stored": self.prepared_request.json
+                is not None,
+                "raw": self.prepared_request.raw,
+            },
+            "template_payload_built": self.template_payload_built,
+            "synthetic_payload_only": self.synthetic_payload_only,
+            "payload_values_stored": self.payload_values_stored,
+            "raw_payload_stored": self.raw_payload_stored,
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "manual_authorization_required": self.manual_authorization_required,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "payload_template_field_names": list(template.keys()),
+            "payload_template_values_masked": True,
+            "sanitized_payload_preview": {
+                field_name: "<masked>" for field_name in template
+            },
+            "prohibited_template_fields": prohibited_template_fields,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": "manual_subaccount_payload_fixture_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
     customer_reference: str = "first-customer-http-client-gate-sandbox"
@@ -2086,6 +2156,33 @@ class AsaasSandboxClient:
 
         return AsaasSandboxSubaccountPayloadContractResult(
             structure_guard=structure_guard,
+        )
+
+    def build_subaccount_payload_builder_guard(
+        self,
+    ) -> AsaasSandboxSubaccountPayloadBuilderGuardResult:
+        payload_contract = self.build_subaccount_payload_contract()
+        sanitized_payload_template: dict[str, Any] = {
+            "name": "<sandbox-subaccount-name>",
+            "email": "<sandbox-subaccount-email>",
+            "cpfCnpj": "<sandbox-subaccount-cpf-cnpj>",
+            "mobilePhone": "<sandbox-subaccount-mobile-phone>",
+            "incomeValue": 0,
+            "address": "<sandbox-subaccount-address>",
+            "addressNumber": "<sandbox-subaccount-address-number>",
+            "province": "<sandbox-subaccount-province>",
+            "postalCode": "<sandbox-subaccount-postal-code>",
+        }
+        prepared_request = self._prepare(
+            method="POST",
+            path="/accounts",
+            operation="create_subaccount_payload_builder_guard",
+            json=sanitized_payload_template,
+        )
+
+        return AsaasSandboxSubaccountPayloadBuilderGuardResult(
+            payload_contract=payload_contract,
+            prepared_request=prepared_request,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2759,3 +2759,95 @@ def test_subaccount_payload_contract_blocks_secret_and_response_only_fields():
     assert "subaccount-api-key-for-test-only" not in rendered_summary
     assert "wallet-id-for-test-only" not in rendered_summary
     assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+
+def test_subaccount_payload_builder_guard_builds_template_without_http_call():
+    client = make_client()
+
+    builder = client.build_subaccount_payload_builder_guard()
+    request = builder.prepared_request
+    summary = builder.safe_summary()
+
+    assert builder.builder_reference == "subaccount-payload-builder-guard-sandbox"
+    assert builder.endpoint_path == "/accounts"
+    assert builder.method == "POST"
+    assert builder.target_operation == "create_subaccount"
+    assert builder.template_payload_built is True
+    assert builder.synthetic_payload_only is True
+    assert builder.payload_values_stored is False
+    assert builder.raw_payload_stored is False
+    assert builder.sandbox_only is True
+    assert builder.production_blocked is True
+    assert builder.manual_authorization_required is True
+    assert builder.can_create_subaccount is False
+    assert builder.can_send_http is False
+    assert builder.real_money is False
+    assert builder.http_call_executed is False
+    assert builder.future_result_marker == (
+        "ASAAS_SANDBOX_SUBACCOUNT_PAYLOAD_BUILDER_GUARD_READY"
+    )
+
+    assert request.method == "POST"
+    assert request.url == f"{ASAAS_SANDBOX_BASE_URL}/accounts"
+    assert request.operation == "create_subaccount_payload_builder_guard"
+    assert request.headers_configured is True
+    assert request.real_money is False
+    assert request.http_call_executed is False
+    assert request.raw["http_execution_blocked"] is True
+
+    assert request.json == {
+        "name": "<sandbox-subaccount-name>",
+        "email": "<sandbox-subaccount-email>",
+        "cpfCnpj": "<sandbox-subaccount-cpf-cnpj>",
+        "mobilePhone": "<sandbox-subaccount-mobile-phone>",
+        "incomeValue": 0,
+        "address": "<sandbox-subaccount-address>",
+        "addressNumber": "<sandbox-subaccount-address-number>",
+        "province": "<sandbox-subaccount-province>",
+        "postalCode": "<sandbox-subaccount-postal-code>",
+    }
+
+    assert summary["operation"] == "subaccount_payload_builder_guard"
+    assert summary["template_payload_built"] is True
+    assert summary["synthetic_payload_only"] is True
+    assert summary["payload_template_values_masked"] is True
+    assert summary["ready_for_http_execution"] is False
+    assert summary["prohibited_template_fields"] == []
+
+
+def test_subaccount_payload_builder_guard_safe_summary_masks_template_values():
+    client = make_client()
+
+    builder = client.build_subaccount_payload_builder_guard()
+    summary = builder.safe_summary()
+    rendered_summary = repr(summary)
+
+    for field_name in (
+        "name",
+        "email",
+        "cpfCnpj",
+        "mobilePhone",
+        "incomeValue",
+        "address",
+        "addressNumber",
+        "province",
+        "postalCode",
+    ):
+        assert field_name in summary["payload_template_field_names"]
+        assert summary["sanitized_payload_preview"][field_name] == "<masked>"
+
+    assert summary["payload_contract"]["operation"] == "subaccount_payload_contract"
+    assert summary["payload_contract"]["ready_for_http_execution"] is False
+    assert summary["prepared_request"]["operation"] == (
+        "create_subaccount_payload_builder_guard"
+    )
+    assert summary["prepared_request"]["json_payload_template_stored"] is True
+    assert summary["prepared_request"]["http_call_executed"] is False
+
+    assert "<sandbox-subaccount-cpf-cnpj>" not in rendered_summary
+    assert "<sandbox-subaccount-email>" not in rendered_summary
+    assert "<sandbox-subaccount-mobile-phone>" not in rendered_summary
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary


### PR DESCRIPTION
## Summary

Adds the Asaas Sandbox subaccount payload builder guard for v0.2.80.

## Scope

- adds AsaasSandboxSubaccountPayloadBuilderGuardResult
- builds a synthetic subaccount payload template for /accounts
- keeps template values synthetic and masked in safe summaries
- keeps payload values storage disabled
- keeps raw payload storage disabled
- keeps subaccount creation blocked
- keeps HTTP sending blocked
- keeps production blocked
- keeps real money disabled
- adds unit tests for template creation and safe summary masking

## Safety

- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure
- synthetic placeholders only

## Validation

- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 89 passed, 1 warning