### PR TITLE
feat(wallet): add Asaas sandbox subaccount sanitized fixture

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -296,6 +296,70 @@ class AsaasSandboxSubaccountPayloadBuilderGuardResult:
 
 
 @dataclass(frozen=True)
+class AsaasSandboxSubaccountSanitizedFixtureResult:
+    builder_guard: AsaasSandboxSubaccountPayloadBuilderGuardResult
+    fixture_reference: str = "subaccount-sanitized-fixture-sandbox"
+    fixture_source: str = "synthetic_sandbox_subaccount_response_fixture"
+    raw_response_stored: bool = False
+    raw_payload_stored: bool = False
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    synthetic_fixture_only: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    api_key_present: bool = True
+    wallet_id_present: bool = True
+    account_id_present: bool = True
+    onboarding_url_present: bool = True
+    sensitive_response_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    sanitized_response_fixture: dict[str, Any] = field(
+        default_factory=lambda: {
+            "object": "account",
+            "id": "<masked>",
+            "apiKey": "<masked>",
+            "walletId": "<masked>",
+            "onboardingUrl": "<masked>",
+            "status": "sandbox_fixture_only",
+        }
+    )
+    future_result_marker: str = "ASAAS_SANDBOX_SUBACCOUNT_SANITIZED_FIXTURE_READY"
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_sanitized_fixture",
+            "fixture_reference": self.fixture_reference,
+            "fixture_source": self.fixture_source,
+            "builder_guard": self.builder_guard.safe_summary(),
+            "raw_response_stored": self.raw_response_stored,
+            "raw_payload_stored": self.raw_payload_stored,
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "synthetic_fixture_only": self.synthetic_fixture_only,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "api_key_present": self.api_key_present,
+            "wallet_id_present": self.wallet_id_present,
+            "account_id_present": self.account_id_present,
+            "onboarding_url_present": self.onboarding_url_present,
+            "sensitive_response_fields": list(self.sensitive_response_fields),
+            "sensitive_response_values_masked": True,
+            "sanitized_response_fixture": self.sanitized_response_fixture,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": "manual_subaccount_response_sanitizer_review",
+        }
+
+
+@dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
     customer_reference: str = "first-customer-http-client-gate-sandbox"
@@ -2183,6 +2247,15 @@ class AsaasSandboxClient:
         return AsaasSandboxSubaccountPayloadBuilderGuardResult(
             payload_contract=payload_contract,
             prepared_request=prepared_request,
+        )
+
+    def build_subaccount_sanitized_fixture(
+        self,
+    ) -> AsaasSandboxSubaccountSanitizedFixtureResult:
+        builder_guard = self.build_subaccount_payload_builder_guard()
+
+        return AsaasSandboxSubaccountSanitizedFixtureResult(
+            builder_guard=builder_guard,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2851,3 +2851,72 @@ def test_subaccount_payload_builder_guard_safe_summary_masks_template_values():
     assert "subaccount-api-key-for-test-only" not in rendered_summary
     assert "wallet-id-for-test-only" not in rendered_summary
     assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+
+def test_subaccount_sanitized_fixture_marks_sensitive_response_fields_present():
+    client = make_client()
+
+    fixture = client.build_subaccount_sanitized_fixture()
+    summary = fixture.safe_summary()
+
+    assert fixture.fixture_reference == "subaccount-sanitized-fixture-sandbox"
+    assert fixture.fixture_source == "synthetic_sandbox_subaccount_response_fixture"
+    assert fixture.raw_response_stored is False
+    assert fixture.raw_payload_stored is False
+    assert fixture.sandbox_only is True
+    assert fixture.production_blocked is True
+    assert fixture.synthetic_fixture_only is True
+    assert fixture.can_create_subaccount is False
+    assert fixture.can_send_http is False
+    assert fixture.real_money is False
+    assert fixture.http_call_executed is False
+    assert fixture.api_key_present is True
+    assert fixture.wallet_id_present is True
+    assert fixture.account_id_present is True
+    assert fixture.onboarding_url_present is True
+    assert fixture.future_result_marker == (
+        "ASAAS_SANDBOX_SUBACCOUNT_SANITIZED_FIXTURE_READY"
+    )
+
+    assert summary["operation"] == "subaccount_sanitized_fixture"
+    assert summary["builder_guard"]["operation"] == (
+        "subaccount_payload_builder_guard"
+    )
+    assert summary["raw_response_stored"] is False
+    assert summary["raw_payload_stored"] is False
+    assert summary["sensitive_response_values_masked"] is True
+    assert summary["ready_for_http_execution"] is False
+
+    for field_name in ("apiKey", "walletId", "id", "onboardingUrl"):
+        assert field_name in summary["sensitive_response_fields"]
+        assert summary["sanitized_response_fixture"][field_name] == "<masked>"
+
+
+def test_subaccount_sanitized_fixture_safe_summary_exposes_no_secret_values():
+    client = make_client()
+
+    fixture = client.build_subaccount_sanitized_fixture()
+    summary = fixture.safe_summary()
+    rendered_summary = repr(summary)
+
+    assert summary["sanitized_response_fixture"] == {
+        "object": "account",
+        "id": "<masked>",
+        "apiKey": "<masked>",
+        "walletId": "<masked>",
+        "onboardingUrl": "<masked>",
+        "status": "sandbox_fixture_only",
+    }
+    assert summary["can_send_http"] is False
+    assert summary["can_create_subaccount"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "acct_" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+    assert "<sandbox-subaccount-cpf-cnpj>" not in rendered_summary
+    assert "<sandbox-subaccount-email>" not in rendered_summary
+    assert "<sandbox-subaccount-mobile-phone>" not in rendered_summary


### PR DESCRIPTION
## Summary

Adds the Asaas Sandbox subaccount sanitized fixture for v0.2.81.

## Scope

- adds AsaasSandboxSubaccountSanitizedFixtureResult
- simulates a sanitized Sandbox subaccount response fixture
- marks apiKey, walletId, id, and onboardingUrl as present but masked
- keeps raw response storage disabled
- keeps raw payload storage disabled
- keeps subaccount creation blocked
- keeps HTTP sending blocked
- keeps production blocked
- keeps real money disabled
- adds unit tests for sanitized fixture behavior and secret masking

## Safety

- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure
- no raw response exposure
- synthetic fixture only

## Validation

- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 91 passed, 1 warning