### PR TITLE
feat(wallet): add Asaas sandbox subaccount response sanitizer contract

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -359,6 +359,86 @@ class AsaasSandboxSubaccountSanitizedFixtureResult:
         }
 
 
+
+@dataclass(frozen=True)
+class AsaasSandboxSubaccountResponseSanitizerContractResult:
+    sanitized_fixture: AsaasSandboxSubaccountSanitizedFixtureResult
+    contract_reference: str = "subaccount-response-sanitizer-contract-sandbox"
+    sanitizer_reference: str = "subaccount-response-sanitizer-sandbox"
+    raw_response_input_expected: bool = True
+    raw_response_stored: bool = False
+    raw_payload_stored: bool = False
+    raw_secret_values_retained: bool = False
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    synthetic_contract_only: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    sensitive_input_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    safe_output_fields: tuple[str, ...] = (
+        "object",
+        "status",
+        "api_key_present",
+        "wallet_id_present",
+        "account_id_present",
+        "onboarding_url_present",
+        "sensitive_response_values_masked",
+    )
+    masked_output_fields: tuple[str, ...] = (
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    blocked_storage_fields: tuple[str, ...] = (
+        "raw_response",
+        "raw_payload",
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+    )
+    future_result_marker: str = (
+        "ASAAS_SANDBOX_SUBACCOUNT_RESPONSE_SANITIZER_CONTRACT_READY"
+    )
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_response_sanitizer_contract",
+            "contract_reference": self.contract_reference,
+            "sanitizer_reference": self.sanitizer_reference,
+            "sanitized_fixture": self.sanitized_fixture.safe_summary(),
+            "raw_response_input_expected": self.raw_response_input_expected,
+            "raw_response_stored": self.raw_response_stored,
+            "raw_payload_stored": self.raw_payload_stored,
+            "raw_secret_values_retained": self.raw_secret_values_retained,
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "synthetic_contract_only": self.synthetic_contract_only,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "sensitive_input_fields": list(self.sensitive_input_fields),
+            "safe_output_fields": list(self.safe_output_fields),
+            "masked_output_fields": list(self.masked_output_fields),
+            "blocked_storage_fields": list(self.blocked_storage_fields),
+            "masking_required": True,
+            "secret_values_allowed": False,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": (
+                "manual_subaccount_response_sanitizer_implementation_review"
+            ),
+        }
+
 @dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
@@ -2256,6 +2336,15 @@ class AsaasSandboxClient:
 
         return AsaasSandboxSubaccountSanitizedFixtureResult(
             builder_guard=builder_guard,
+        )
+
+    def build_subaccount_response_sanitizer_contract(
+        self,
+    ) -> AsaasSandboxSubaccountResponseSanitizerContractResult:
+        sanitized_fixture = self.build_subaccount_sanitized_fixture()
+
+        return AsaasSandboxSubaccountResponseSanitizerContractResult(
+            sanitized_fixture=sanitized_fixture,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2920,3 +2920,86 @@ def test_subaccount_sanitized_fixture_safe_summary_exposes_no_secret_values():
     assert "<sandbox-subaccount-cpf-cnpj>" not in rendered_summary
     assert "<sandbox-subaccount-email>" not in rendered_summary
     assert "<sandbox-subaccount-mobile-phone>" not in rendered_summary
+
+
+def test_subaccount_response_sanitizer_contract_defines_safe_output_rules():
+    client = make_client()
+
+    contract = client.build_subaccount_response_sanitizer_contract()
+    summary = contract.safe_summary()
+
+    assert contract.contract_reference == (
+        "subaccount-response-sanitizer-contract-sandbox"
+    )
+    assert contract.sanitizer_reference == "subaccount-response-sanitizer-sandbox"
+    assert contract.raw_response_input_expected is True
+    assert contract.raw_response_stored is False
+    assert contract.raw_payload_stored is False
+    assert contract.raw_secret_values_retained is False
+    assert contract.sandbox_only is True
+    assert contract.production_blocked is True
+    assert contract.synthetic_contract_only is True
+    assert contract.can_create_subaccount is False
+    assert contract.can_send_http is False
+    assert contract.real_money is False
+    assert contract.http_call_executed is False
+    assert contract.future_result_marker == (
+        "ASAAS_SANDBOX_SUBACCOUNT_RESPONSE_SANITIZER_CONTRACT_READY"
+    )
+
+    assert summary["operation"] == "subaccount_response_sanitizer_contract"
+    assert summary["contract_reference"] == contract.contract_reference
+    assert summary["sanitizer_reference"] == contract.sanitizer_reference
+    assert summary["sanitized_fixture"]["operation"] == "subaccount_sanitized_fixture"
+    assert summary["raw_response_input_expected"] is True
+    assert summary["raw_response_stored"] is False
+    assert summary["raw_payload_stored"] is False
+    assert summary["raw_secret_values_retained"] is False
+    assert summary["masking_required"] is True
+    assert summary["secret_values_allowed"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["next_step_required"] == (
+        "manual_subaccount_response_sanitizer_implementation_review"
+    )
+
+    for field_name in (
+        "api_key_present",
+        "wallet_id_present",
+        "account_id_present",
+        "onboarding_url_present",
+        "sensitive_response_values_masked",
+    ):
+        assert field_name in summary["safe_output_fields"]
+
+
+def test_subaccount_response_sanitizer_contract_blocks_raw_secret_storage():
+    client = make_client()
+
+    contract = client.build_subaccount_response_sanitizer_contract()
+    summary = contract.safe_summary()
+    rendered_summary = repr(summary)
+
+    for field_name in ("apiKey", "walletId", "id", "onboardingUrl"):
+        assert field_name in summary["sensitive_input_fields"]
+        assert field_name in summary["masked_output_fields"]
+        assert field_name in summary["blocked_storage_fields"]
+
+    assert "raw_response" in summary["blocked_storage_fields"]
+    assert "raw_payload" in summary["blocked_storage_fields"]
+    assert summary["raw_response_stored"] is False
+    assert summary["raw_payload_stored"] is False
+    assert summary["raw_secret_values_retained"] is False
+    assert summary["can_send_http"] is False
+    assert summary["can_create_subaccount"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "acct_" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+    assert "<sandbox-subaccount-cpf-cnpj>" not in rendered_summary
+    assert "<sandbox-subaccount-email>" not in rendered_summary
+    assert "<sandbox-subaccount-mobile-phone>" not in rendered_summary


### PR DESCRIPTION
## Summary
Adds the Asaas Sandbox subaccount response sanitizer contract for v0.2.82.

## Scope
- adds AsaasSandboxSubaccountResponseSanitizerContractResult
- defines sensitive input fields for future raw Asaas subaccount responses
- defines safe output fields for sanitized summaries
- defines masked output fields
- blocks raw response and raw payload storage
- blocks apiKey, walletId, id, and onboardingUrl from raw storage
- keeps subaccount creation blocked
- keeps HTTP sending blocked
- keeps production blocked
- keeps real money disabled
- adds unit tests for safe output rules and secret storage blocking

## Safety
- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure
- no raw response exposure
- sanitizer contract only

## Validation
- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 93 passed, 1 warning