### PR TITLE
feat(wallet): implement Asaas sandbox subaccount response sanitizer

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -439,6 +439,59 @@ class AsaasSandboxSubaccountResponseSanitizerContractResult:
             ),
         }
 
+
+@dataclass(frozen=True)
+class AsaasSandboxSubaccountResponseSanitizerImplementationResult:
+    contract: AsaasSandboxSubaccountResponseSanitizerContractResult
+    sanitized_output: dict[str, Any]
+    implementation_reference: str = (
+        "subaccount-response-sanitizer-implementation-sandbox"
+    )
+    sanitizer_reference: str = "subaccount-response-sanitizer-sandbox"
+    raw_response_input_received: bool = True
+    raw_response_stored: bool = False
+    raw_payload_stored: bool = False
+    raw_secret_values_retained: bool = False
+    sanitizer_implemented: bool = True
+    sandbox_only: bool = True
+    production_blocked: bool = True
+    synthetic_input_only: bool = True
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    future_result_marker: str = (
+        "ASAAS_SANDBOX_SUBACCOUNT_RESPONSE_SANITIZER_IMPLEMENTATION_READY"
+    )
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_response_sanitizer_implementation",
+            "implementation_reference": self.implementation_reference,
+            "sanitizer_reference": self.sanitizer_reference,
+            "contract": self.contract.safe_summary(),
+            "sanitized_output": self.sanitized_output,
+            "raw_response_input_received": self.raw_response_input_received,
+            "raw_response_stored": self.raw_response_stored,
+            "raw_payload_stored": self.raw_payload_stored,
+            "raw_secret_values_retained": self.raw_secret_values_retained,
+            "sanitizer_implemented": self.sanitizer_implemented,
+            "sandbox_only": self.sandbox_only,
+            "production_blocked": self.production_blocked,
+            "synthetic_input_only": self.synthetic_input_only,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "masking_required": True,
+            "secret_values_allowed": False,
+            "ready_for_http_execution": False,
+            "future_result_marker": self.future_result_marker,
+            "next_step_required": (
+                "manual_subaccount_response_sanitizer_execution_review"
+            ),
+        }
+
 @dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
@@ -2345,6 +2398,27 @@ class AsaasSandboxClient:
 
         return AsaasSandboxSubaccountResponseSanitizerContractResult(
             sanitized_fixture=sanitized_fixture,
+        )
+
+    def sanitize_subaccount_response(
+        self,
+        raw_response: dict[str, Any],
+    ) -> AsaasSandboxSubaccountResponseSanitizerImplementationResult:
+        contract = self.build_subaccount_response_sanitizer_contract()
+
+        sanitized_output = {
+            "object": raw_response.get("object"),
+            "status": raw_response.get("status"),
+            "api_key_present": bool(raw_response.get("apiKey")),
+            "wallet_id_present": bool(raw_response.get("walletId")),
+            "account_id_present": bool(raw_response.get("id")),
+            "onboarding_url_present": bool(raw_response.get("onboardingUrl")),
+            "sensitive_response_values_masked": True,
+        }
+
+        return AsaasSandboxSubaccountResponseSanitizerImplementationResult(
+            contract=contract,
+            sanitized_output=sanitized_output,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -3003,3 +3003,95 @@ def test_subaccount_response_sanitizer_contract_blocks_raw_secret_storage():
     assert "<sandbox-subaccount-cpf-cnpj>" not in rendered_summary
     assert "<sandbox-subaccount-email>" not in rendered_summary
     assert "<sandbox-subaccount-mobile-phone>" not in rendered_summary
+
+
+def test_subaccount_response_sanitizer_implementation_returns_safe_output():
+    client = make_client()
+
+    result = client.sanitize_subaccount_response(
+        {
+            "object": "account",
+            "id": "acct_subaccount_for_test_only",
+            "apiKey": "subaccount-api-key-for-test-only",
+            "walletId": "wallet-id-for-test-only",
+            "onboardingUrl": "https://sandbox.asaas.com/onboarding/test-only",
+            "status": "sandbox_fixture_only",
+        }
+    )
+    summary = result.safe_summary()
+    sanitized_output = summary["sanitized_output"]
+
+    assert result.implementation_reference == (
+        "subaccount-response-sanitizer-implementation-sandbox"
+    )
+    assert result.sanitizer_reference == "subaccount-response-sanitizer-sandbox"
+    assert result.raw_response_input_received is True
+    assert result.raw_response_stored is False
+    assert result.raw_payload_stored is False
+    assert result.raw_secret_values_retained is False
+    assert result.sanitizer_implemented is True
+    assert result.sandbox_only is True
+    assert result.production_blocked is True
+    assert result.synthetic_input_only is True
+    assert result.can_create_subaccount is False
+    assert result.can_send_http is False
+    assert result.real_money is False
+    assert result.http_call_executed is False
+
+    assert summary["operation"] == "subaccount_response_sanitizer_implementation"
+    assert summary["contract"]["operation"] == (
+        "subaccount_response_sanitizer_contract"
+    )
+    assert summary["masking_required"] is True
+    assert summary["secret_values_allowed"] is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["next_step_required"] == (
+        "manual_subaccount_response_sanitizer_execution_review"
+    )
+    assert summary["future_result_marker"] == (
+        "ASAAS_SANDBOX_SUBACCOUNT_RESPONSE_SANITIZER_IMPLEMENTATION_READY"
+    )
+
+    assert sanitized_output == {
+        "object": "account",
+        "status": "sandbox_fixture_only",
+        "api_key_present": True,
+        "wallet_id_present": True,
+        "account_id_present": True,
+        "onboarding_url_present": True,
+        "sensitive_response_values_masked": True,
+    }
+
+
+def test_subaccount_response_sanitizer_implementation_exposes_no_raw_values():
+    client = make_client()
+
+    result = client.sanitize_subaccount_response(
+        {
+            "object": "account",
+            "id": "acct_subaccount_for_test_only",
+            "apiKey": "subaccount-api-key-for-test-only",
+            "walletId": "wallet-id-for-test-only",
+            "onboardingUrl": "https://sandbox.asaas.com/onboarding/test-only",
+            "status": "sandbox_fixture_only",
+            "ignoredRawField": "this-raw-field-must-not-be-exposed",
+        }
+    )
+    summary = result.safe_summary()
+    rendered_summary = repr(summary)
+
+    assert summary["raw_response_stored"] is False
+    assert summary["raw_payload_stored"] is False
+    assert summary["raw_secret_values_retained"] is False
+    assert summary["can_send_http"] is False
+    assert summary["can_create_subaccount"] is False
+    assert summary["real_money"] is False
+    assert summary["http_call_executed"] is False
+
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "acct_subaccount_for_test_only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+    assert "this-raw-field-must-not-be-exposed" not in rendered_summary
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary


### PR DESCRIPTION
## Summary
Implements the Asaas Sandbox subaccount response sanitizer for v0.2.83.

## Scope
- adds AsaasSandboxSubaccountResponseSanitizerImplementationResult
- adds sanitize_subaccount_response()
- sanitizes synthetic raw subaccount responses
- exposes only safe boolean presence fields
- keeps object/status as safe fields
- blocks raw response storage
- blocks raw payload storage
- blocks raw secret value retention
- verifies apiKey, walletId, id, onboardingUrl do not leak in safe summaries
- adds unit tests for safe output and raw value blocking

## Safety
- no external POST request
- no subaccount created
- no production usage
- no real money movement
- no balance credit
- no real receipt generation
- no API key exposure
- no webhook token exposure
- no walletId exposure
- no onboardingUrl exposure
- no raw payload exposure
- no raw response exposure
- sanitizer implementation only with synthetic input

## Validation
- git diff --check passed
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- 95 passed, 1 warning