### PR TITLE
test(wallet): add Asaas sandbox subaccount first controlled attempt record contract

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -716,6 +716,95 @@ class AsaasSandboxSubaccountFirstControlledAttemptPreflightResult:
             ),
         }
 
+
+@dataclass(frozen=True)
+class AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult:
+    preflight: AsaasSandboxSubaccountFirstControlledAttemptPreflightResult
+    record_contract_reference: str = (
+        "subaccount-first-controlled-attempt-record-contract-sandbox"
+    )
+    allowed_record_fields: tuple[str, ...] = (
+        "operation",
+        "environment",
+        "target_method",
+        "target_path",
+        "request_executed",
+        "http_call_executed",
+        "http_status_code",
+        "subaccount_created",
+        "object",
+        "api_key_present",
+        "wallet_id_present",
+        "account_id_present",
+        "onboarding_url_present",
+        "sensitive_response_values_masked",
+        "raw_payload_stored",
+        "raw_response_stored",
+        "raw_error_stored",
+        "raw_headers_stored",
+        "production_used",
+        "real_money",
+        "retry_loop_used",
+        "next_step_required",
+    )
+    forbidden_record_fields: tuple[str, ...] = (
+        "access_token",
+        "apiKey",
+        "walletId",
+        "id",
+        "onboardingUrl",
+        "raw_payload",
+        "raw_response",
+        "raw_error",
+        "raw_headers",
+        "webhook_token",
+        "env_file",
+    )
+    record_contract_defined: bool = True
+    record_contract_valid: bool = False
+    can_create_record_after_future_attempt: bool = False
+    raw_payload_storage_allowed: bool = False
+    raw_response_storage_allowed: bool = False
+    raw_error_storage_allowed: bool = False
+    raw_headers_storage_allowed: bool = False
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    network_call_allowed: bool = False
+    real_money: bool = False
+    http_call_executed: bool = False
+    sandbox_only: bool = True
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": (
+                "subaccount_first_controlled_attempt_record_contract"
+            ),
+            "record_contract_reference": self.record_contract_reference,
+            "preflight": self.preflight.safe_summary(),
+            "allowed_record_fields": list(self.allowed_record_fields),
+            "forbidden_record_fields": list(self.forbidden_record_fields),
+            "record_contract_defined": self.record_contract_defined,
+            "record_contract_valid": self.record_contract_valid,
+            "can_create_record_after_future_attempt": (
+                self.can_create_record_after_future_attempt
+            ),
+            "raw_payload_storage_allowed": self.raw_payload_storage_allowed,
+            "raw_response_storage_allowed": self.raw_response_storage_allowed,
+            "raw_error_storage_allowed": self.raw_error_storage_allowed,
+            "raw_headers_storage_allowed": self.raw_headers_storage_allowed,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "network_call_allowed": self.network_call_allowed,
+            "real_money": self.real_money,
+            "http_call_executed": self.http_call_executed,
+            "sandbox_only": self.sandbox_only,
+            "ready_for_http_execution": False,
+            "next_step_required": (
+                "manual_first_controlled_sandbox_attempt_decision"
+            ),
+        }
+
+
 @dataclass(frozen=True)
 class AsaasFirstCustomerHttpClientGateResult:
     prepared_request: AsaasPreparedRequest
@@ -2699,6 +2788,29 @@ class AsaasSandboxClient:
             http_call_executed=manual_execution_gate.http_call_executed,
             sandbox_only=manual_execution_gate.sandbox_only,
             production_blocked=manual_execution_gate.production_blocked,
+        )
+
+
+    def build_subaccount_first_controlled_attempt_record_contract(
+        self,
+        *,
+        manual_authorization_phrase: str = "",
+    ) -> AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult:
+        preflight = self.build_subaccount_first_controlled_attempt_preflight(
+            manual_authorization_phrase=manual_authorization_phrase,
+        )
+        contract_valid = preflight.first_controlled_attempt_preflight_valid
+
+        return AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult(
+            preflight=preflight,
+            record_contract_valid=contract_valid,
+            can_create_record_after_future_attempt=contract_valid,
+            can_create_subaccount=False,
+            can_send_http=False,
+            network_call_allowed=False,
+            real_money=False,
+            http_call_executed=False,
+            sandbox_only=preflight.sandbox_only,
         )
 
     def gate_first_customer_http_call(

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -3276,3 +3276,67 @@ def test_subaccount_first_controlled_attempt_preflight_blocks_invalid_phrase_and
     assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
     assert "sandbox-api-key-for-test-only" not in rendered_summary
     assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+
+def test_subaccount_first_controlled_attempt_record_contract_is_sanitized():
+    client = make_client()
+
+    contract = client.build_subaccount_first_controlled_attempt_record_contract(
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+    )
+    summary = contract.safe_summary()
+
+    assert contract.record_contract_reference == (
+        "subaccount-first-controlled-attempt-record-contract-sandbox"
+    )
+    assert contract.record_contract_defined is True
+    assert contract.record_contract_valid is True
+    assert contract.can_create_record_after_future_attempt is True
+    assert contract.raw_payload_storage_allowed is False
+    assert contract.raw_response_storage_allowed is False
+    assert contract.raw_error_storage_allowed is False
+    assert contract.raw_headers_storage_allowed is False
+    assert contract.can_create_subaccount is False
+    assert contract.can_send_http is False
+    assert contract.network_call_allowed is False
+    assert contract.real_money is False
+    assert contract.http_call_executed is False
+
+    assert summary["operation"] == (
+        "subaccount_first_controlled_attempt_record_contract"
+    )
+    assert summary["record_contract_valid"] is True
+    assert summary["ready_for_http_execution"] is False
+    assert summary["next_step_required"] == (
+        "manual_first_controlled_sandbox_attempt_decision"
+    )
+
+    assert "api_key_present" in summary["allowed_record_fields"]
+    assert "wallet_id_present" in summary["allowed_record_fields"]
+    assert "onboarding_url_present" in summary["allowed_record_fields"]
+    assert "raw_payload" in summary["forbidden_record_fields"]
+    assert "raw_response" in summary["forbidden_record_fields"]
+    assert "raw_headers" in summary["forbidden_record_fields"]
+
+    rendered_summary = repr(summary)
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "acct_subaccount_for_test_only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+
+
+def test_subaccount_first_controlled_attempt_record_contract_blocks_invalid_gate():
+    client = make_client()
+
+    contract = client.build_subaccount_first_controlled_attempt_record_contract(
+        manual_authorization_phrase="EXECUTAR POST SANDBOX SUBCONTA AGORA",
+    )
+    summary = contract.safe_summary()
+
+    assert contract.record_contract_valid is False
+    assert contract.can_create_record_after_future_attempt is False
+    assert summary["record_contract_valid"] is False
+    assert summary["can_create_record_after_future_attempt"] is False
+    assert summary["can_create_subaccount"] is False
+    assert summary["can_send_http"] is False
+    assert summary["network_call_allowed"] is False
+    assert summary["http_call_executed"] is False


### PR DESCRIPTION
## Summary
Adds a compact sanitized record contract for the future first controlled Asaas Sandbox subaccount attempt for v0.2.89.

## Scope
- Adds `AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult`
- Adds `build_subaccount_first_controlled_attempt_record_contract()`
- Reuses the existing subaccount preflight instead of adding a new document
- Defines allowed sanitized record fields
- Defines forbidden raw/sensitive record fields
- Adds valid/invalid gate tests

## Safety
- No external POST executed
- No subaccount created
- No production flow
- No real money
- No API key, webhook token, walletId, onboardingUrl, raw payload, raw response, raw error or raw headers exposed
- can_send_http=false
- can_create_subaccount=false
- network_call_allowed=false
- http_call_executed=false

## Validation
- git diff --check
- PYTHONPATH=backend pytest backend/tests/test_asaas_config_guards.py backend/tests/test_asaas_client_skeleton.py backend/tests/test_asaas_webhook_receiver.py -q
- Result: 101 passed, 1 warning