### PR TITLE
feat(wallet): add controlled Asaas sandbox subaccount post attempt

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from app.partner.asaas_config import (
+    ASAAS_SANDBOX_BASE_URL,
     ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
     AsaasSandboxConfig,
     load_asaas_sandbox_config,
@@ -802,6 +803,107 @@ class AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult:
             "next_step_required": (
                 "manual_first_controlled_sandbox_attempt_decision"
             ),
+        }
+
+
+@dataclass(frozen=True)
+class AsaasSandboxSubaccountFirstControlledPostAttemptResult:
+    record_contract: AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult
+    prepared_request: AsaasPreparedRequest
+    attempt_reference: str = (
+        "subaccount-first-controlled-post-attempt-sandbox"
+    )
+    manual_authorization_registered: bool = False
+    final_operator_confirmation_registered: bool = False
+    attempt_policy: dict[str, Any] = field(
+        default_factory=lambda: {
+            "single_attempt_only": True,
+            "retry_loop_enabled": False,
+            "sandbox_only": True,
+            "production_blocked": True,
+            "real_money": False,
+            "raw_payload_storage_allowed": False,
+            "raw_response_storage_allowed": False,
+            "raw_error_storage_allowed": False,
+            "raw_headers_storage_allowed": False,
+            "external_http_requires_injected_transport": True,
+        }
+    )
+    http_status_code: int | None = None
+    subaccount_created: bool = False
+    object: str | None = None
+    api_key_present: bool = False
+    wallet_id_present: bool = False
+    account_id_present: bool = False
+    onboarding_url_present: bool = False
+    sensitive_response_values_masked: bool = True
+    raw_payload_stored: bool = False
+    raw_response_stored: bool = False
+    raw_error_stored: bool = False
+    raw_headers_stored: bool = False
+    production_used: bool = False
+    real_money: bool = False
+    retry_loop_used: bool = False
+    can_create_subaccount: bool = False
+    can_send_http: bool = False
+    network_call_allowed: bool = False
+    http_call_executed: bool = False
+    sanitized_attempt_record_created: bool = False
+    next_step_required: str = "manual_controlled_sandbox_post_execution"
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "subaccount_first_controlled_post_attempt",
+            "attempt_reference": self.attempt_reference,
+            "record_contract": self.record_contract.safe_summary(),
+            "prepared_request": {
+                "method": self.prepared_request.method,
+                "url": self.prepared_request.url,
+                "operation": self.prepared_request.operation,
+                "headers_configured": self.prepared_request.headers_configured,
+                "json_payload_stored": self.prepared_request.json is not None,
+                "json_payload_values_masked": True,
+                "real_money": self.prepared_request.real_money,
+                "http_call_executed": self.prepared_request.http_call_executed,
+                "raw": self.prepared_request.raw,
+            },
+            "manual_authorization_registered": (
+                self.manual_authorization_registered
+            ),
+            "final_operator_confirmation_registered": (
+                self.final_operator_confirmation_registered
+            ),
+            "attempt_policy": self.attempt_policy,
+            "http_status_code": self.http_status_code,
+            "subaccount_created": self.subaccount_created,
+            "object": self.object,
+            "api_key_present": self.api_key_present,
+            "wallet_id_present": self.wallet_id_present,
+            "account_id_present": self.account_id_present,
+            "onboarding_url_present": self.onboarding_url_present,
+            "sensitive_response_values_masked": (
+                self.sensitive_response_values_masked
+            ),
+            "raw_payload_stored": self.raw_payload_stored,
+            "raw_response_stored": self.raw_response_stored,
+            "raw_error_stored": self.raw_error_stored,
+            "raw_headers_stored": self.raw_headers_stored,
+            "production_used": self.production_used,
+            "real_money": self.real_money,
+            "retry_loop_used": self.retry_loop_used,
+            "can_create_subaccount": self.can_create_subaccount,
+            "can_send_http": self.can_send_http,
+            "network_call_allowed": self.network_call_allowed,
+            "http_call_executed": self.http_call_executed,
+            "sanitized_attempt_record_created": (
+                self.sanitized_attempt_record_created
+            ),
+            "ready_for_http_execution": (
+                self.can_send_http
+                and self.network_call_allowed
+                and not self.http_call_executed
+            ),
+            "next_step_required": self.next_step_required,
         }
 
 
@@ -2812,6 +2914,144 @@ class AsaasSandboxClient:
             http_call_executed=False,
             sandbox_only=preflight.sandbox_only,
         )
+
+
+    def execute_subaccount_first_controlled_post_attempt(
+        self,
+        *,
+        name: str,
+        email: str,
+        cpf_cnpj: str,
+        mobile_phone: str,
+        income_value: Decimal,
+        address: str,
+        address_number: str,
+        province: str,
+        postal_code: str,
+        manual_authorization_phrase: str = "",
+        final_operator_confirmation: bool = False,
+        http_post: Callable[
+            [AsaasPreparedRequest],
+            tuple[int, dict[str, Any]],
+        ] | None = None,
+    ) -> AsaasSandboxSubaccountFirstControlledPostAttemptResult:
+        record_contract = self.build_subaccount_first_controlled_attempt_record_contract(
+            manual_authorization_phrase=manual_authorization_phrase,
+        )
+        manual_authorization_registered = (
+            manual_authorization_phrase.strip()
+            == ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE
+        )
+        target_allowed = (
+            self.config.env == "sandbox"
+            and self.base_url == ASAAS_SANDBOX_BASE_URL.rstrip("/")
+            and record_contract.record_contract_valid
+            and manual_authorization_registered
+            and final_operator_confirmation
+        )
+        payload = {
+            "name": name,
+            "email": email,
+            "cpfCnpj": cpf_cnpj,
+            "mobilePhone": mobile_phone,
+            "incomeValue": float(income_value),
+            "address": address,
+            "addressNumber": address_number,
+            "province": province,
+            "postalCode": postal_code,
+        }
+        executable_request = self._prepare(
+            method="POST",
+            path="/accounts",
+            operation="create_subaccount_first_controlled_post_attempt",
+            json=payload,
+        )
+        masked_request = self._prepare(
+            method="POST",
+            path="/accounts",
+            operation="create_subaccount_first_controlled_post_attempt",
+            json={
+                "name": "<masked>",
+                "email": "<masked>",
+                "cpfCnpj": "<masked>",
+                "mobilePhone": "<masked>",
+                "incomeValue": "<masked>",
+                "address": "<masked>",
+                "addressNumber": "<masked>",
+                "province": "<masked>",
+                "postalCode": "<masked>",
+            },
+        )
+        can_send_http = bool(
+            target_allowed
+            and executable_request.headers_configured
+            and http_post is not None
+        )
+
+        if not can_send_http:
+            return AsaasSandboxSubaccountFirstControlledPostAttemptResult(
+                record_contract=record_contract,
+                prepared_request=masked_request,
+                manual_authorization_registered=manual_authorization_registered,
+                final_operator_confirmation_registered=final_operator_confirmation,
+                can_create_subaccount=False,
+                can_send_http=False,
+                network_call_allowed=False,
+                http_call_executed=False,
+                sanitized_attempt_record_created=False,
+            )
+
+        try:
+            http_status_code, raw_response = http_post(executable_request)
+        except Exception:
+            return AsaasSandboxSubaccountFirstControlledPostAttemptResult(
+                record_contract=record_contract,
+                prepared_request=masked_request,
+                manual_authorization_registered=manual_authorization_registered,
+                final_operator_confirmation_registered=final_operator_confirmation,
+                http_status_code=None,
+                can_create_subaccount=False,
+                can_send_http=True,
+                network_call_allowed=True,
+                http_call_executed=True,
+                sanitized_attempt_record_created=True,
+                next_step_required="review_sanitized_transport_error_and_stop",
+            )
+
+        sanitized = self.sanitize_subaccount_response(raw_response)
+        sanitized_output = sanitized.sanitized_output
+        success_status = http_status_code in (200, 201)
+        subaccount_created = bool(
+            success_status and sanitized_output.get("account_id_present")
+        )
+        next_step_required = (
+            "validate_subaccount_permissions_and_onboarding_url"
+            if subaccount_created
+            else "review_sanitized_provider_error_and_stop"
+        )
+
+        return AsaasSandboxSubaccountFirstControlledPostAttemptResult(
+            record_contract=record_contract,
+            prepared_request=masked_request,
+            manual_authorization_registered=manual_authorization_registered,
+            final_operator_confirmation_registered=final_operator_confirmation,
+            http_status_code=http_status_code,
+            subaccount_created=subaccount_created,
+            object=sanitized_output.get("object"),
+            api_key_present=bool(sanitized_output.get("api_key_present")),
+            wallet_id_present=bool(sanitized_output.get("wallet_id_present")),
+            account_id_present=bool(sanitized_output.get("account_id_present")),
+            onboarding_url_present=bool(
+                sanitized_output.get("onboarding_url_present")
+            ),
+            can_create_subaccount=subaccount_created,
+            can_send_http=True,
+            network_call_allowed=True,
+            http_call_executed=True,
+            sanitized_attempt_record_created=True,
+            next_step_required=next_step_required,
+        )
+
 
     def gate_first_customer_http_call(
         self,

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -3340,3 +3340,224 @@ def test_subaccount_first_controlled_attempt_record_contract_blocks_invalid_gate
     assert summary["can_send_http"] is False
     assert summary["network_call_allowed"] is False
     assert summary["http_call_executed"] is False
+
+
+def test_subaccount_first_controlled_post_attempt_stays_blocked_without_final_confirmation():
+    client = make_client()
+
+    attempt = client.execute_subaccount_first_controlled_post_attempt(
+        name="Subconta Teste Aurea Gold",
+        email="subconta.teste@example.com",
+        cpf_cnpj="19540550000121",
+        mobile_phone="47999999999",
+        income_value=Decimal("1000.00"),
+        address="Rua Teste",
+        address_number="123",
+        province="Centro",
+        postal_code="89200000",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+        final_operator_confirmation=False,
+    )
+    summary = attempt.safe_summary()
+
+    assert attempt.attempt_reference == (
+        "subaccount-first-controlled-post-attempt-sandbox"
+    )
+    assert attempt.manual_authorization_registered is True
+    assert attempt.final_operator_confirmation_registered is False
+    assert attempt.can_create_subaccount is False
+    assert attempt.can_send_http is False
+    assert attempt.network_call_allowed is False
+    assert attempt.http_call_executed is False
+    assert attempt.sanitized_attempt_record_created is False
+    assert summary["ready_for_http_execution"] is False
+    assert summary["prepared_request"]["json_payload_values_masked"] is True
+
+    rendered_summary = repr(summary)
+    assert "19540550000121" not in rendered_summary
+    assert "subconta.teste@example.com" not in rendered_summary
+    assert "47999999999" not in rendered_summary
+    assert "Rua Teste" not in rendered_summary
+
+
+def test_subaccount_first_controlled_post_attempt_uses_injected_transport_once_and_sanitizes_response():
+    client = make_client()
+    calls = []
+
+    def fake_http_post(request):
+        calls.append(request)
+        return 200, {
+            "object": "account",
+            "id": "acct_subaccount_for_test_only",
+            "apiKey": "subaccount-api-key-for-test-only",
+            "walletId": "wallet-id-for-test-only",
+            "onboardingUrl": "https://sandbox.asaas.com/onboarding/test-only",
+        }
+
+    attempt = client.execute_subaccount_first_controlled_post_attempt(
+        name="Subconta Teste Aurea Gold",
+        email="subconta.teste@example.com",
+        cpf_cnpj="19540550000121",
+        mobile_phone="47999999999",
+        income_value=Decimal("1000.00"),
+        address="Rua Teste",
+        address_number="123",
+        province="Centro",
+        postal_code="89200000",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+        final_operator_confirmation=True,
+        http_post=fake_http_post,
+    )
+    summary = attempt.safe_summary()
+
+    assert len(calls) == 1
+    assert calls[0].method == "POST"
+    assert calls[0].url.endswith("/accounts")
+    assert calls[0].operation == (
+        "create_subaccount_first_controlled_post_attempt"
+    )
+    assert calls[0].json["cpfCnpj"] == "19540550000121"
+
+    assert attempt.can_create_subaccount is True
+    assert attempt.can_send_http is True
+    assert attempt.network_call_allowed is True
+    assert attempt.http_call_executed is True
+    assert attempt.retry_loop_used is False
+    assert attempt.raw_payload_stored is False
+    assert attempt.raw_response_stored is False
+    assert attempt.raw_error_stored is False
+    assert attempt.raw_headers_stored is False
+    assert attempt.production_used is False
+    assert attempt.real_money is False
+    assert attempt.sanitized_attempt_record_created is True
+
+    assert summary["http_status_code"] == 200
+    assert summary["subaccount_created"] is True
+    assert summary["object"] == "account"
+    assert summary["api_key_present"] is True
+    assert summary["wallet_id_present"] is True
+    assert summary["account_id_present"] is True
+    assert summary["onboarding_url_present"] is True
+    assert summary["sensitive_response_values_masked"] is True
+    assert summary["next_step_required"] == (
+        "validate_subaccount_permissions_and_onboarding_url"
+    )
+
+    rendered_summary = repr(summary)
+    assert "subaccount-api-key-for-test-only" not in rendered_summary
+    assert "wallet-id-for-test-only" not in rendered_summary
+    assert "acct_subaccount_for_test_only" not in rendered_summary
+    assert "https://sandbox.asaas.com/onboarding/test-only" not in rendered_summary
+    assert "19540550000121" not in rendered_summary
+    assert "subconta.teste@example.com" not in rendered_summary
+
+
+def test_subaccount_first_controlled_post_attempt_blocks_invalid_phrase_even_with_transport():
+    client = make_client()
+    calls = []
+
+    def fake_http_post(request):
+        calls.append(request)
+        return 200, {"object": "account"}
+
+    attempt = client.execute_subaccount_first_controlled_post_attempt(
+        name="Subconta Teste Aurea Gold",
+        email="subconta.teste@example.com",
+        cpf_cnpj="19540550000121",
+        mobile_phone="47999999999",
+        income_value=Decimal("1000.00"),
+        address="Rua Teste",
+        address_number="123",
+        province="Centro",
+        postal_code="89200000",
+        manual_authorization_phrase="EXECUTAR POST SANDBOX SUBCONTA AGORA",
+        final_operator_confirmation=True,
+        http_post=fake_http_post,
+    )
+
+    assert calls == []
+    assert attempt.manual_authorization_registered is False
+    assert attempt.can_create_subaccount is False
+    assert attempt.can_send_http is False
+    assert attempt.network_call_allowed is False
+    assert attempt.http_call_executed is False
+
+
+def test_subaccount_first_controlled_post_attempt_does_not_mark_error_response_as_created():
+    client = make_client()
+    calls = []
+
+    def fake_http_post(request):
+        calls.append(request)
+        return 400, {
+            "object": "account",
+            "id": "unexpected-id-for-error-test-only",
+        }
+
+    attempt = client.execute_subaccount_first_controlled_post_attempt(
+        name="Subconta Teste Aurea Gold",
+        email="subconta.teste@example.com",
+        cpf_cnpj="19540550000121",
+        mobile_phone="47999999999",
+        income_value=Decimal("1000.00"),
+        address="Rua Teste",
+        address_number="123",
+        province="Centro",
+        postal_code="89200000",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+        final_operator_confirmation=True,
+        http_post=fake_http_post,
+    )
+    summary = attempt.safe_summary()
+
+    assert len(calls) == 1
+    assert attempt.http_call_executed is True
+    assert attempt.http_status_code == 400
+    assert attempt.subaccount_created is False
+    assert attempt.can_create_subaccount is False
+    assert summary["subaccount_created"] is False
+    assert summary["next_step_required"] == (
+        "review_sanitized_provider_error_and_stop"
+    )
+    assert "unexpected-id-for-error-test-only" not in repr(summary)
+
+
+def test_subaccount_first_controlled_post_attempt_sanitizes_transport_exception():
+    client = make_client()
+    calls = []
+
+    def fake_http_post(request):
+        calls.append(request)
+        raise RuntimeError(
+            "raw transport failure with access_token and secret test value"
+        )
+
+    attempt = client.execute_subaccount_first_controlled_post_attempt(
+        name="Subconta Teste Aurea Gold",
+        email="subconta.teste@example.com",
+        cpf_cnpj="19540550000121",
+        mobile_phone="47999999999",
+        income_value=Decimal("1000.00"),
+        address="Rua Teste",
+        address_number="123",
+        province="Centro",
+        postal_code="89200000",
+        manual_authorization_phrase=ASAAS_SANDBOX_MANUAL_AUTHORIZATION_PHRASE,
+        final_operator_confirmation=True,
+        http_post=fake_http_post,
+    )
+    summary = attempt.safe_summary()
+
+    assert len(calls) == 1
+    assert attempt.http_call_executed is True
+    assert attempt.http_status_code is None
+    assert attempt.subaccount_created is False
+    assert attempt.raw_error_stored is False
+    assert attempt.sanitized_attempt_record_created is True
+    assert summary["next_step_required"] == (
+        "review_sanitized_transport_error_and_stop"
+    )
+
+    rendered_summary = repr(summary)
+    assert "raw transport failure" not in rendered_summary
+    assert "secret test value" not in rendered_summary


### PR DESCRIPTION
## Objetivo
Preparar o executor controlado da primeira tentativa Sandbox POST /accounts.

## Entrega
- autorização manual obrigatória
- confirmação final obrigatória
- alvo restrito ao Sandbox oficial
- transporte injetado e execução única
- sem retry loop
- tratamento de status HTTP 200/201 e erros
- sanitização de apiKey, walletId, id e onboardingUrl
- exceções de transporte sem exposição de erro bruto

## Validação
- 106 passed, 1 warning
- pre-commit OK
- SECURITY_DIFF_SCAN_OK

## Segurança
Nenhum POST real ao Asaas foi executado nesta entrega. Sem produção, sem dinheiro real e sem armazenamento de payload, resposta, erro ou headers brutos.