### PR TITLE
test(wallet): add Asaas sandbox rate limit and error handling

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, Mapping
 
 from app.partner.asaas_config import (
     ASAAS_SANDBOX_BASE_URL,
@@ -802,6 +802,74 @@ class AsaasSandboxSubaccountFirstControlledAttemptRecordContractResult:
             "ready_for_http_execution": False,
             "next_step_required": (
                 "manual_first_controlled_sandbox_attempt_decision"
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class AsaasSanitizedRateLimitAndErrorResult:
+    status_code: int
+    category: str
+    safe_message: str
+    retryable: bool
+    retry_delay_seconds: int | None = None
+    rate_limit_limit_present: bool = False
+    rate_limit_remaining_present: bool = False
+    rate_limit_reset_present: bool = False
+    retry_after_present: bool = False
+    rate_limit_remaining_zero: bool = False
+    provider_error_code_present: bool = False
+    rate_limit_limit: int | None = None
+    rate_limit_remaining: int | None = None
+    rate_limit_reset_seconds: int | None = None
+    retry_after_seconds: int | None = None
+    rate_limit_near_limit: bool = False
+    retry_loop_enabled: bool = False
+    raw_headers_stored: bool = False
+    raw_response_stored: bool = False
+    raw_error_stored: bool = False
+    secret_values_allowed: bool = False
+    production_used: bool = False
+    real_money: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": "asaas_rate_limit_and_error_classification",
+            "status_code": self.status_code,
+            "category": self.category,
+            "safe_message": self.safe_message,
+            "retryable": self.retryable,
+            "retry_delay_seconds": self.retry_delay_seconds,
+            "rate_limit_limit_present": self.rate_limit_limit_present,
+            "rate_limit_remaining_present": (
+                self.rate_limit_remaining_present
+            ),
+            "rate_limit_reset_present": self.rate_limit_reset_present,
+            "retry_after_present": self.retry_after_present,
+            "rate_limit_remaining_zero": self.rate_limit_remaining_zero,
+            "provider_error_code_present": (
+                self.provider_error_code_present
+            ),
+            "rate_limit_limit": self.rate_limit_limit,
+            "rate_limit_remaining": self.rate_limit_remaining,
+            "rate_limit_reset_seconds": self.rate_limit_reset_seconds,
+            "retry_after_seconds": self.retry_after_seconds,
+            "rate_limit_near_limit": self.rate_limit_near_limit,
+            "retry_loop_enabled": self.retry_loop_enabled,
+            "raw_headers_stored": self.raw_headers_stored,
+            "raw_response_stored": self.raw_response_stored,
+            "raw_error_stored": self.raw_error_stored,
+            "secret_values_allowed": self.secret_values_allowed,
+            "production_used": self.production_used,
+            "real_money": self.real_money,
+            "next_step_required": (
+                "schedule_bounded_retry_after_delay"
+                if self.retryable and self.retry_delay_seconds is not None
+                else (
+                    "manual_retry_review_required"
+                    if self.retryable
+                    else "fix_request_or_configuration_before_retry"
+                )
             ),
         }
 
@@ -2913,6 +2981,115 @@ class AsaasSandboxClient:
             real_money=False,
             http_call_executed=False,
             sandbox_only=preflight.sandbox_only,
+        )
+
+
+    def classify_rate_limit_and_error_response(
+        self,
+        *,
+        status_code: int,
+        headers: Mapping[str, str] | None = None,
+        provider_error_code: str | None = None,
+    ) -> AsaasSanitizedRateLimitAndErrorResult:
+        normalized_headers = {
+            str(name).strip().lower(): str(value).strip()
+            for name, value in (headers or {}).items()
+        }
+
+        def parse_non_negative_int(header_name: str) -> int | None:
+            raw_value = normalized_headers.get(header_name.lower())
+            if raw_value is None:
+                return None
+            try:
+                parsed = int(raw_value)
+            except (TypeError, ValueError):
+                return None
+            return parsed if parsed >= 0 else None
+
+        rate_limit_limit = parse_non_negative_int("ratelimit-limit")
+        rate_limit_remaining = parse_non_negative_int(
+            "ratelimit-remaining"
+        )
+        rate_limit_reset = parse_non_negative_int("ratelimit-reset")
+        retry_after = parse_non_negative_int("retry-after")
+
+        retry_delay_seconds = (
+            retry_after
+            if retry_after is not None
+            else rate_limit_reset
+        )
+
+        if 200 <= status_code < 300:
+            category = "provider_success"
+            safe_message = "provider_request_succeeded"
+            retryable = False
+        elif status_code in (400, 422):
+            category = "provider_validation_error"
+            safe_message = "provider_rejected_invalid_request"
+            retryable = False
+        elif status_code == 401:
+            category = "provider_authentication_error"
+            safe_message = "provider_authentication_failed"
+            retryable = False
+        elif status_code == 403:
+            category = "provider_authorization_error"
+            safe_message = "provider_authorization_denied"
+            retryable = False
+        elif status_code == 404:
+            category = "provider_not_found"
+            safe_message = "provider_resource_not_found"
+            retryable = False
+        elif status_code == 408:
+            category = "provider_timeout"
+            safe_message = "provider_request_timeout"
+            retryable = True
+        elif status_code == 429:
+            category = "provider_rate_limit_error"
+            safe_message = "provider_rate_limit_reached"
+            retryable = True
+        elif 500 <= status_code <= 599:
+            category = "provider_unavailable"
+            safe_message = "provider_temporarily_unavailable"
+            retryable = True
+        else:
+            category = "unexpected_provider_error"
+            safe_message = "unexpected_provider_response"
+            retryable = False
+
+        if not retryable:
+            retry_delay_seconds = None
+
+        rate_limit_near_limit = bool(
+            rate_limit_limit is not None
+            and rate_limit_limit > 0
+            and rate_limit_remaining is not None
+            and rate_limit_remaining
+            <= max(1, rate_limit_limit // 10)
+        )
+
+        return AsaasSanitizedRateLimitAndErrorResult(
+            status_code=status_code,
+            category=category,
+            safe_message=safe_message,
+            retryable=retryable,
+            retry_delay_seconds=retry_delay_seconds,
+            rate_limit_limit_present=(
+                "ratelimit-limit" in normalized_headers
+            ),
+            rate_limit_remaining_present=(
+                "ratelimit-remaining" in normalized_headers
+            ),
+            rate_limit_reset_present=(
+                "ratelimit-reset" in normalized_headers
+            ),
+            retry_after_present="retry-after" in normalized_headers,
+            rate_limit_remaining_zero=rate_limit_remaining == 0,
+            provider_error_code_present=bool(provider_error_code),
+            rate_limit_limit=rate_limit_limit,
+            rate_limit_remaining=rate_limit_remaining,
+            rate_limit_reset_seconds=rate_limit_reset,
+            retry_after_seconds=retry_after,
+            rate_limit_near_limit=rate_limit_near_limit,
         )
 
 

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -3567,3 +3567,129 @@ def test_subaccount_first_controlled_post_attempt_sanitizes_transport_exception(
     rendered_summary = repr(summary)
     assert "raw transport failure" not in rendered_summary
     assert "secret test value" not in rendered_summary
+
+
+def test_asaas_rate_limit_classifier_handles_429_with_reset_without_raw_headers():
+    client = make_client()
+
+    result = client.classify_rate_limit_and_error_response(
+        status_code=429,
+        headers={
+            "RateLimit-Limit": "100",
+            "RateLimit-Remaining": "0",
+            "RateLimit-Reset": "30",
+            "access_token": "sandbox-secret-for-test-only",
+        },
+        provider_error_code="rate_limit_exceeded",
+    )
+    summary = result.safe_summary()
+
+    assert result.category == "provider_rate_limit_error"
+    assert result.retryable is True
+    assert result.retry_delay_seconds == 30
+    assert result.rate_limit_limit_present is True
+    assert result.rate_limit_remaining_present is True
+    assert result.rate_limit_reset_present is True
+    assert result.rate_limit_remaining_zero is True
+    assert result.provider_error_code_present is True
+    assert result.retry_loop_enabled is False
+    assert result.raw_headers_stored is False
+    assert result.raw_response_stored is False
+    assert result.raw_error_stored is False
+    assert result.secret_values_allowed is False
+
+    assert summary["rate_limit_limit"] == 100
+    assert summary["rate_limit_remaining"] == 0
+    assert summary["rate_limit_reset_seconds"] == 30
+    assert summary["retry_after_seconds"] is None
+    assert summary["rate_limit_near_limit"] is True
+    assert summary["next_step_required"] == (
+        "schedule_bounded_retry_after_delay"
+    )
+
+    rendered_summary = repr(summary)
+    assert "sandbox-secret-for-test-only" not in rendered_summary
+    assert "access_token" not in rendered_summary
+    assert "rate_limit_exceeded" not in rendered_summary
+
+
+def test_asaas_error_classifier_maps_non_retryable_client_errors():
+    client = make_client()
+
+    expected = {
+        400: "provider_validation_error",
+        401: "provider_authentication_error",
+        403: "provider_authorization_error",
+        404: "provider_not_found",
+        422: "provider_validation_error",
+    }
+
+    for status_code, category in expected.items():
+        result = client.classify_rate_limit_and_error_response(
+            status_code=status_code,
+            headers={"RateLimit-Remaining": "99"},
+        )
+        summary = result.safe_summary()
+
+        assert result.category == category
+        assert result.retryable is False
+        assert result.retry_delay_seconds is None
+        assert result.retry_loop_enabled is False
+        assert summary["next_step_required"] == (
+            "fix_request_or_configuration_before_retry"
+        )
+
+
+def test_asaas_error_classifier_marks_timeout_and_server_errors_retryable_without_loop():
+    client = make_client()
+
+    for status_code in (408, 500, 502, 503):
+        result = client.classify_rate_limit_and_error_response(
+            status_code=status_code,
+        )
+        summary = result.safe_summary()
+
+        assert result.retryable is True
+        assert result.retry_delay_seconds is None
+        assert result.retry_loop_enabled is False
+        assert result.production_used is False
+        assert result.real_money is False
+        assert summary["next_step_required"] == (
+            "manual_retry_review_required"
+        )
+
+
+def test_asaas_rate_limit_classifier_ignores_malformed_header_values_safely():
+    client = make_client()
+
+    result = client.classify_rate_limit_and_error_response(
+        status_code=429,
+        headers={
+            "RateLimit-Limit": "not-a-number",
+            "RateLimit-Remaining": "-1",
+            "RateLimit-Reset": "secret-reset-value",
+            "Retry-After": "invalid",
+        },
+    )
+    summary = result.safe_summary()
+
+    assert result.category == "provider_rate_limit_error"
+    assert result.retryable is True
+    assert result.retry_delay_seconds is None
+    assert result.rate_limit_limit_present is True
+    assert result.rate_limit_remaining_present is True
+    assert result.rate_limit_reset_present is True
+    assert result.retry_after_present is True
+    assert result.rate_limit_limit is None
+    assert result.rate_limit_remaining is None
+    assert result.rate_limit_reset_seconds is None
+    assert result.retry_after_seconds is None
+    assert result.rate_limit_near_limit is False
+    assert result.rate_limit_remaining_zero is False
+    assert summary["next_step_required"] == (
+        "manual_retry_review_required"
+    )
+
+    rendered_summary = repr(summary)
+    assert "not-a-number" not in rendered_summary
+    assert "secret-reset-value" not in rendered_summary


### PR DESCRIPTION
## Objetivo

Adicionar tratamento sanitizado e reutilizável para rate limits e erros HTTP do Asaas Sandbox, sem realizar chamadas externas.

## Implementado

- classificação de respostas 400, 401, 403, 404, 408, 422, 429 e 5xx
- suporte seguro aos headers RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset e Retry-After
- detecção de cota próxima do limite
- prioridade de Retry-After sobre RateLimit-Reset
- retry apenas classificado, sem loop automático
- bloqueio de headers, respostas, erros brutos e segredos
- nenhuma constante documental fixa usada como regra de execução
- nenhuma chamada real ao Asaas

## Validação

- git diff --check
- 110 passed
- 1 warning conhecido do passlib
- pre-commit OK

## Segurança

- Sandbox only
- produção não utilizada
- dinheiro real não utilizado
- nenhum token ou payload bruto armazenado