### PR TITLE
test(wallet): harden Asaas sandbox webhook retry and idempotency

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from decimal import Decimal
 from datetime import datetime, timezone
 import hashlib
@@ -949,34 +949,15 @@ def handle_asaas_sandbox_webhook_receiver(
             response["can_mark_real_paid"] = False
             return response
 
-        return {
-            "ok": True,
-            "service": "aurea-wallet",
-            "duplicated": True,
-            "event": {
-                "provider": "asaas",
-                "environment": "sandbox",
-                "event_id_present": True,
-                "event_type": event_type,
-                "status": "in_progress",
-            },
-            "wallet": {
-                "mode": WALLET_MODE,
-                "provider": provider,
-                "source": "asaas_sandbox",
-                "real_money_enabled": False,
-            },
-            "idempotency": {
-                "key": idem_key,
-                "request_hash": request_hash,
-                "replayed": True,
-                "state": "in_progress",
-            },
-            "can_credit_balance": False,
-            "can_generate_real_receipt": False,
-            "can_mark_real_paid": False,
-            "notice": "Evento Asaas Sandbox já está em processamento. Nenhum dinheiro real foi movimentado.",
-        }
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Evento Asaas Sandbox aguardando conclusão "
+                "do processamento anterior."
+            ),
+            headers={"Retry-After": "30"},
+        )
+
 
     accepted = event_type in _ASAAS_SANDBOX_WEBHOOK_ACCEPTED_EVENTS
     payment_payload = payload.get("payment") if isinstance(payload.get("payment"), dict) else {}
@@ -1067,8 +1048,21 @@ def handle_asaas_sandbox_webhook_receiver(
     }
 
     record.status_code = 200
-    record.response_json = json.dumps(response, ensure_ascii=False, default=str)
-    db.commit()
+    record.response_json = json.dumps(
+        response,
+        ensure_ascii=False,
+        default=str,
+    )
+
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(
+            status_code=503,
+            detail="Webhook Asaas Sandbox temporariamente indisponível.",
+            headers={"Retry-After": "30"},
+        ) from None
 
     return response
 

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.api.v1.routes import wallet as wallet_routes
 
@@ -46,11 +46,13 @@ class FakeQuery:
 
 
 class FakeDb:
-    def __init__(self):
+    def __init__(self, *, fail_commit=False):
         self.records = {}
         self.pending = None
         self.committed = False
         self.rolled_back = False
+        self.fail_commit = fail_commit
+        self.transaction_inserted_keys = []
 
     def add(self, record):
         self.pending = record
@@ -58,14 +60,25 @@ class FakeDb:
     def flush(self):
         if self.pending.key in self.records:
             raise IntegrityError("duplicate", {}, Exception("duplicate"))
-        self.records[self.pending.key] = self.pending
+        inserted_key = self.pending.key
+        self.records[inserted_key] = self.pending
+        self.transaction_inserted_keys.append(inserted_key)
         self.pending = None
 
     def rollback(self):
         self.rolled_back = True
+        self.pending = None
+        for key in self.transaction_inserted_keys:
+            self.records.pop(key, None)
+        self.transaction_inserted_keys.clear()
 
     def commit(self):
+        if self.fail_commit:
+            raise SQLAlchemyError(
+                "database commit failure with secret test value"
+            )
         self.committed = True
+        self.transaction_inserted_keys.clear()
 
     def query(self, _model):
         return FakeQuery(self)
@@ -318,3 +331,76 @@ def test_asaas_sandbox_webhook_audit_history_ignores_malformed_or_non_asaas_reco
     assert len(items) == 1
     assert items[0]["provider"] == "asaas"
     assert items[0]["event_type"] == "PAYMENT_RECEIVED"
+
+
+
+def test_asaas_sandbox_webhook_returns_503_for_incomplete_duplicate():
+    db = FakeDb()
+    payload = _valid_payload()
+    event_id = wallet_routes._asaas_sandbox_webhook_event_id(payload)
+    idem_key = wallet_routes._asaas_sandbox_webhook_idempotency_key(
+        event_id
+    )
+    request_hash = wallet_routes._asaas_sandbox_webhook_hash(payload)
+
+    db.records[idem_key] = SimpleNamespace(
+        key=idem_key,
+        request_hash=request_hash,
+        status_code=None,
+        response_json=None,
+        created_at=None,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+
+    rendered = json.dumps(
+        {
+            "detail": exc.value.detail,
+            "headers": exc.value.headers,
+        },
+        ensure_ascii=False,
+    )
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers == {"Retry-After": "30"}
+    assert db.rolled_back is True
+    assert db.committed is False
+    assert idem_key in db.records
+    assert "secret-token" not in rendered
+    assert "evt_test_unique_001" not in rendered
+    assert "pay_real_sandbox_must_not_leak" not in rendered
+
+
+def test_asaas_sandbox_webhook_commit_failure_rolls_back_and_returns_503():
+    db = FakeDb(fail_commit=True)
+
+    with pytest.raises(HTTPException) as exc:
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=_valid_payload(),
+            db=db,
+            asaas_access_token="secret-token",
+        )
+
+    rendered = json.dumps(
+        {
+            "detail": exc.value.detail,
+            "headers": exc.value.headers,
+        },
+        ensure_ascii=False,
+    )
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers == {"Retry-After": "30"}
+    assert db.rolled_back is True
+    assert db.committed is False
+    assert db.records == {}
+    assert "database commit failure" not in rendered
+    assert "secret test value" not in rendered
+    assert "secret-token" not in rendered
+    assert "evt_test_unique_001" not in rendered
+    assert "pay_real_sandbox_must_not_leak" not in rendered


### PR DESCRIPTION
## Objetivo

Fortalecer o receiver de webhook do Asaas Sandbox para que falhas temporárias não sejam tratadas como entregas concluídas.

## Implementado

- duplicata com processamento incompleto retorna HTTP 503
- resposta inclui Retry-After: 30
- replay concluído continua retornando HTTP 200
- falha no commit do banco executa rollback
- falha de banco retorna resposta sanitizada
- preservação da idempotência por evento
- nenhum token, event ID, payment ID ou erro interno exposto
- nenhuma movimentação de dinheiro real

## Validação

- teste específico do receiver: 9 passed
- regressão ampliada Asaas: 112 passed
- 1 warning conhecido do passlib
- git diff --check OK
- pre-commit OK

## Segurança

- Sandbox only
- nenhuma chamada externa ao Asaas
- produção não utilizada
- dinheiro real não utilizado
- payload bruto não armazenado