### PR TITLE
feat(wallet): add sandbox webhook statement projection

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -14,7 +14,11 @@ from app.models.transaction import Transaction
 from app.models.idempotency import IdempotencyKey
 from app.models.user_main import User
 from app.config import WALLET_MODE, IS_PARTNER_WALLET
-from app.partner import PartnerWebhookEvent, get_partner_adapter
+from app.partner import (
+    PartnerWebhookEvent,
+    StatementItem,
+    get_partner_adapter,
+)
 from app.partner.asaas_config import AsaasConfigError, load_asaas_sandbox_config
 from app.services.wallet_partner_service import (
     create_wallet_pix_payment as create_partner_pix_payment,
@@ -211,10 +215,90 @@ def _statement_item_payload(item, *, source: str, real_money_enabled: bool) -> d
     }
 
 
+def _sandbox_statement_items_from_webhooks(
+    db: Session,
+    *,
+    user_id: int,
+    limit: int,
+) -> list[StatementItem]:
+    safe_limit = max(1, min(int(limit or 50), 100))
+    rows = (
+        db.query(IdempotencyKey)
+        .filter(IdempotencyKey.key.like("wallet-sandbox-webhook:%"))
+        .order_by(IdempotencyKey.created_at.desc())
+        .limit(min(safe_limit * 4, 400))
+        .all()
+    )
+
+    items: list[StatementItem] = []
+    seen_references: set[str] = set()
+
+    for row in rows:
+        raw_response = getattr(row, "response_json", None)
+        if not raw_response:
+            continue
+
+        try:
+            response = json.loads(raw_response)
+        except (TypeError, ValueError):
+            continue
+
+        if response.get("user_id") != user_id:
+            continue
+
+        event = response.get("event") or {}
+        event_type = str(event.get("event_type") or "").strip()
+        status = str(event.get("status") or "").strip().lower()
+
+        if event_type != "pix.payment.confirmed" or status != "confirmed":
+            continue
+
+        provider_reference = _safe_receipt_part(
+            event.get("provider_reference")
+        )
+        if (
+            provider_reference == "not-provided"
+            or provider_reference in seen_references
+        ):
+            continue
+
+        try:
+            amount = Decimal(str(event.get("amount") or "0.00"))
+        except Exception:
+            continue
+
+        if amount <= Decimal("0.00"):
+            continue
+
+        seen_references.add(provider_reference)
+        items.append(
+            StatementItem(
+                provider_reference=provider_reference,
+                amount=amount,
+                direction="credit",
+                status="confirmed",
+                description="PIX sandbox confirmado",
+                created_at=event.get("received_at"),
+                raw={
+                    "sandbox": True,
+                    "real_money": False,
+                    "source": "wallet_sandbox_webhook",
+                },
+            )
+        )
+
+        if len(items) >= safe_limit:
+            break
+
+    return items
+
+
+
 @router.get("/api/v1/wallet/structured-statement")
 def get_wallet_structured_statement(
     limit: int = 50,
     current_user: User = Depends(require_customer),
+    db: Session = Depends(get_db),
 ):
     """
     Extrato estruturado da wallet.
@@ -236,13 +320,32 @@ def get_wallet_structured_statement(
     try:
         adapter = get_partner_adapter()
         provider = adapter.provider_name
-        statement = get_partner_wallet_statement(
-            user_id=current_user.id,
-            limit=safe_limit,
+        statement = list(
+            get_partner_wallet_statement(
+                user_id=current_user.id,
+                limit=safe_limit,
+            )
         )
+
+        if provider == "sandbox":
+            statement.extend(
+                _sandbox_statement_items_from_webhooks(
+                    db,
+                    user_id=current_user.id,
+                    limit=safe_limit,
+                )
+            )
+            statement = statement[:safe_limit]
+
         mode = WALLET_MODE
-        source = "partner" if IS_PARTNER_WALLET else "demo"
-        real_money_enabled = bool(IS_PARTNER_WALLET)
+        source = (
+            "sandbox"
+            if provider == "sandbox"
+            else ("partner" if IS_PARTNER_WALLET else "demo")
+        )
+        real_money_enabled = bool(
+            IS_PARTNER_WALLET and provider != "sandbox"
+        )
         adapter_error = None
     except Exception as exc:
         provider = "not_configured"
@@ -1186,6 +1289,7 @@ def handle_wallet_pix_sandbox_webhook(
     response = {
         "ok": True,
         "service": "aurea-wallet",
+        "user_id": getattr(current_user, "id", None),
         "duplicated": False,
         "event": {
             "provider": "sandbox",

--- a/backend/tests/test_wallet_sandbox_end_to_end_statement.py
+++ b/backend/tests/test_wallet_sandbox_end_to_end_statement.py
@@ -1,0 +1,228 @@
+import json
+import os
+from decimal import Decimal
+from types import SimpleNamespace
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+
+from sqlalchemy.exc import IntegrityError
+
+from app.api.v1.routes import wallet as wallet_routes
+from app.partner import PixPaymentRequest, SandboxPartnerAdapter
+
+
+class FakeQuery:
+    def __init__(self, db):
+        self.db = db
+        self.key = None
+        self.row_limit = None
+
+    def filter_by(self, **kwargs):
+        self.key = kwargs.get("key")
+        return self
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, value):
+        self.row_limit = int(value)
+        return self
+
+    def first(self):
+        return self.db.records.get(self.key)
+
+    def all(self):
+        rows = list(self.db.records.values())
+        if self.row_limit is not None:
+            rows = rows[: self.row_limit]
+        return rows
+
+
+class FakeDb:
+    def __init__(self):
+        self.records = {}
+        self.pending = None
+        self.transaction_inserted_keys = []
+
+    def add(self, record):
+        self.pending = record
+
+    def flush(self):
+        if self.pending.key in self.records:
+            raise IntegrityError("duplicate", {}, Exception("duplicate"))
+
+        key = self.pending.key
+        self.records[key] = self.pending
+        self.transaction_inserted_keys.append(key)
+        self.pending = None
+
+    def rollback(self):
+        self.pending = None
+        for key in self.transaction_inserted_keys:
+            self.records.pop(key, None)
+        self.transaction_inserted_keys.clear()
+
+    def commit(self):
+        self.transaction_inserted_keys.clear()
+
+    def query(self, _model):
+        return FakeQuery(self)
+
+
+def _configure_sandbox(monkeypatch):
+    adapter = SandboxPartnerAdapter()
+
+    monkeypatch.setattr(wallet_routes, "WALLET_MODE", "partner")
+    monkeypatch.setattr(wallet_routes, "IS_PARTNER_WALLET", True)
+    monkeypatch.setattr(
+        wallet_routes,
+        "get_partner_adapter",
+        lambda: adapter,
+    )
+    monkeypatch.setattr(
+        wallet_routes,
+        "create_partner_pix_payment",
+        lambda **kwargs: adapter.create_pix_payment(
+            PixPaymentRequest(
+                user_id=kwargs["user_id"],
+                amount=Decimal(kwargs["amount"]),
+                description=kwargs["description"],
+                external_id=kwargs["external_id"],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        wallet_routes,
+        "handle_partner_wallet_webhook",
+        adapter.handle_webhook,
+    )
+    monkeypatch.setattr(
+        wallet_routes,
+        "get_partner_wallet_statement",
+        lambda **_kwargs: [],
+    )
+
+
+def test_wallet_sandbox_end_to_end_payment_webhook_statement(monkeypatch):
+    _configure_sandbox(monkeypatch)
+
+    db = FakeDb()
+    user = SimpleNamespace(id=321)
+
+    payment = wallet_routes.create_wallet_pix_sandbox_payment(
+        payload=wallet_routes.WalletPixSandboxPaymentIn(
+            amount=Decimal("99.90"),
+            description="Fluxo ponta a ponta Sandbox",
+            external_id="e2e-payment-001",
+        ),
+        current_user=user,
+    )
+
+    provider_reference = payment["payment"]["provider_reference"]
+
+    assert provider_reference == "e2e-payment-001"
+    assert payment["payment"]["status"] == "pending"
+    assert (
+        payment["payment"]["qr_code"]
+        == "SANDBOX_QR_CODE_NOT_FOR_REAL_PAYMENT"
+    )
+    assert payment["wallet"]["real_money_enabled"] is False
+
+    webhook_payload = wallet_routes.WalletPixSandboxWebhookIn(
+        provider_reference=provider_reference,
+        event_type="pix.payment.confirmed",
+        status="confirmed",
+        amount=Decimal("99.90"),
+        idempotency_key="e2e-webhook-001",
+        raw={"provider_secret": "must-not-leak"},
+    )
+
+    first = wallet_routes.handle_wallet_pix_sandbox_webhook(
+        payload=webhook_payload,
+        current_user=user,
+        db=db,
+        x_idempotency_key="e2e-webhook-001",
+    )
+    replay = wallet_routes.handle_wallet_pix_sandbox_webhook(
+        payload=webhook_payload,
+        current_user=user,
+        db=db,
+        x_idempotency_key="e2e-webhook-001",
+    )
+
+    statement = wallet_routes.get_wallet_structured_statement(
+        limit=50,
+        current_user=user,
+        db=db,
+    )
+
+    assert first["duplicated"] is False
+    assert first["user_id"] == 321
+    assert first["can_credit_balance"] is False
+    assert replay["duplicated"] is True
+    assert replay["idempotency"]["replayed"] is True
+
+    assert statement["statement"]["count"] == 1
+    assert statement["wallet"]["provider"] == "sandbox"
+    assert statement["wallet"]["source"] == "sandbox"
+    assert statement["wallet"]["real_money_enabled"] is False
+
+    item = statement["statement"]["items"][0]
+
+    assert item == {
+        "provider_reference": "e2e-payment-001",
+        "direction": "credit",
+        "amount": "99.90",
+        "status": "confirmed",
+        "description": "PIX sandbox confirmado",
+        "created_at": first["event"]["received_at"],
+        "source": "sandbox",
+        "real_money_enabled": False,
+    }
+
+    rendered = json.dumps(
+        {
+            "payment": payment,
+            "statement": statement,
+        },
+        ensure_ascii=False,
+        default=str,
+    )
+
+    assert "must-not-leak" not in rendered
+    assert "provider_secret" not in rendered
+
+
+def test_sandbox_statement_does_not_mix_events_between_users(monkeypatch):
+    _configure_sandbox(monkeypatch)
+
+    db = FakeDb()
+    first_user = SimpleNamespace(id=321)
+    second_user = SimpleNamespace(id=654)
+
+    wallet_routes.handle_wallet_pix_sandbox_webhook(
+        payload=wallet_routes.WalletPixSandboxWebhookIn(
+            provider_reference="private-user-321-payment",
+            event_type="pix.payment.confirmed",
+            status="confirmed",
+            amount=Decimal("25.00"),
+            idempotency_key="private-user-321-event",
+        ),
+        current_user=first_user,
+        db=db,
+        x_idempotency_key="private-user-321-event",
+    )
+
+    second_statement = wallet_routes.get_wallet_structured_statement(
+        limit=50,
+        current_user=second_user,
+        db=db,
+    )
+
+    assert second_statement["statement"]["count"] == 0
+    assert second_statement["statement"]["items"] == []
+    assert second_statement["wallet"]["real_money_enabled"] is False


### PR DESCRIPTION
## Objetivo

Validar localmente o fluxo ponta a ponta da Wallet Sandbox:

cobrança → QR sintético → webhook confirmado → replay idempotente → extrato estruturado.

## Implementado

- vinculação sanitizada do webhook ao user_id
- projeção de eventos confirmados no extrato
- filtro rigoroso por usuário
- deduplicação por provider_reference
- somente eventos pix.payment.confirmed com status confirmed
- adapter Sandbox permanece sem dinheiro real
- replay idempotente não duplica item no extrato
- payload bruto não é projetado no extrato

## Validação

- teste específico: 2 passed
- regressão ampliada: 114 passed
- 1 warning conhecido do passlib
- git diff --check OK
- pre-commit OK

## Limites

- fluxo interno da Wallet Sandbox
- não representa integração real com o Asaas
- nenhuma chamada HTTP externa
- produção não utilizada
- dinheiro real não utilizado