### PR TITLE
test(wallet): add Asaas payment user correlation contract

### DIFF
--- a/backend/app/partner/asaas_client.py
+++ b/backend/app/partner/asaas_client.py
@@ -4032,6 +4032,7 @@ class AsaasSandboxClient:
         value: Decimal,
         due_date: str,
         description: str,
+        external_reference: str | None = None,
     ) -> AsaasPreparedRequest:
         payload = {
             "customer": customer_id,
@@ -4040,6 +4041,12 @@ class AsaasSandboxClient:
             "dueDate": due_date,
             "description": description,
         }
+
+        if external_reference is not None:
+            normalized_external_reference = str(external_reference).strip()
+            if not normalized_external_reference:
+                raise ValueError("external_reference não pode ser vazio.")
+            payload["externalReference"] = normalized_external_reference
 
         return self._prepare(
             method="POST",
@@ -4055,12 +4062,14 @@ class AsaasSandboxClient:
         value: Decimal,
         due_date: str,
         description: str,
+        external_reference: str | None = None,
     ) -> AsaasPaymentDryRunResult:
         prepared_request = self.prepare_create_pix_payment(
             customer_id=customer_id,
             value=value,
             due_date=due_date,
             description=description,
+            external_reference=external_reference,
         )
 
         return AsaasPaymentDryRunResult(prepared_request=prepared_request)

--- a/backend/app/partner/asaas_payment_correlation.py
+++ b/backend/app/partner/asaas_payment_correlation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+import secrets
+from typing import Any
+
+from app.models.idempotency import IdempotencyKey
+
+
+ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX = "agpay_"
+ASAAS_PAYMENT_CORRELATION_KEY_PREFIX = "asaas-payment-correlation:"
+ASAAS_PAYMENT_CORRELATION_CONTRACT = (
+    "asaas_payment_user_correlation_v1"
+)
+
+_EXTERNAL_REFERENCE_PATTERN = re.compile(
+    rf"^{ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX}[a-f0-9]{{32}}$"
+)
+
+
+@dataclass(frozen=True)
+class AsaasPaymentUserCorrelation:
+    user_id: int
+    correlation_key: str
+    provider: str = "asaas"
+    environment: str = "sandbox"
+    raw_external_reference_stored: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "environment": self.environment,
+            "user_id_present": True,
+            "correlation_key_present": bool(self.correlation_key),
+            "external_reference_present": True,
+            "raw_external_reference_stored": (
+                self.raw_external_reference_stored
+            ),
+            "correlation_status": "resolved",
+        }
+
+
+def generate_asaas_payment_external_reference() -> str:
+    return (
+        f"{ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX}"
+        f"{secrets.token_hex(16)}"
+    )
+
+
+def validate_asaas_payment_external_reference(
+    external_reference: str,
+) -> str:
+    normalized = str(external_reference or "").strip()
+
+    if not _EXTERNAL_REFERENCE_PATTERN.fullmatch(normalized):
+        raise ValueError(
+            "external_reference Asaas deve ser uma referência opaca "
+            "gerada pela Aurea Gold."
+        )
+
+    return normalized
+
+
+def asaas_payment_correlation_key(
+    external_reference: str,
+) -> str:
+    normalized = validate_asaas_payment_external_reference(
+        external_reference
+    )
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"{ASAAS_PAYMENT_CORRELATION_KEY_PREFIX}{digest}"
+
+
+def _normalize_user_id(user_id: int) -> int:
+    if isinstance(user_id, bool):
+        raise ValueError("user_id inválido para correlação Asaas.")
+
+    try:
+        normalized = int(user_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "user_id inválido para correlação Asaas."
+        ) from exc
+
+    if normalized <= 0:
+        raise ValueError("user_id inválido para correlação Asaas.")
+
+    return normalized
+
+
+def build_asaas_payment_user_correlation_record(
+    *,
+    user_id: int,
+    external_reference: str,
+) -> IdempotencyKey:
+    normalized_user_id = _normalize_user_id(user_id)
+    correlation_key = asaas_payment_correlation_key(
+        external_reference
+    )
+
+    request_hash = hashlib.sha256(
+        f"{correlation_key}|{normalized_user_id}".encode("utf-8")
+    ).hexdigest()
+
+    stored_contract = {
+        "contract": ASAAS_PAYMENT_CORRELATION_CONTRACT,
+        "provider": "asaas",
+        "environment": "sandbox",
+        "user_id": normalized_user_id,
+        "correlation_status": "registered",
+        "external_reference_present": True,
+        "raw_external_reference_stored": False,
+        "can_credit_balance": False,
+        "real_money_enabled": False,
+    }
+
+    return IdempotencyKey(
+        key=correlation_key,
+        request_hash=request_hash,
+        status_code=201,
+        response_json=json.dumps(
+            stored_contract,
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+    )
+
+
+def resolve_asaas_payment_user_correlation(
+    db,
+    *,
+    external_reference: str,
+) -> AsaasPaymentUserCorrelation | None:
+    correlation_key = asaas_payment_correlation_key(
+        external_reference
+    )
+    record = (
+        db.query(IdempotencyKey)
+        .filter_by(key=correlation_key)
+        .first()
+    )
+
+    if not record or not getattr(record, "response_json", None):
+        return None
+
+    try:
+        stored_contract = json.loads(record.response_json)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+    if (
+        stored_contract.get("contract")
+        != ASAAS_PAYMENT_CORRELATION_CONTRACT
+    ):
+        return None
+
+    try:
+        user_id = _normalize_user_id(
+            stored_contract.get("user_id")
+        )
+    except ValueError:
+        return None
+
+    return AsaasPaymentUserCorrelation(
+        user_id=user_id,
+        correlation_key=correlation_key,
+    )
+
+
+def resolve_asaas_payment_user_correlation_from_payment(
+    db,
+    *,
+    payment_payload: dict,
+) -> AsaasPaymentUserCorrelation | None:
+    if not isinstance(payment_payload, dict):
+        return None
+
+    external_reference = (
+        payment_payload.get("externalReference")
+        or payment_payload.get("external_reference")
+    )
+
+    if external_reference is None:
+        return None
+
+    try:
+        return resolve_asaas_payment_user_correlation(
+            db,
+            external_reference=str(external_reference),
+        )
+    except ValueError:
+        return None

--- a/backend/tests/test_asaas_client_skeleton.py
+++ b/backend/tests/test_asaas_client_skeleton.py
@@ -2303,6 +2303,23 @@ def test_prepare_create_pix_payment_builds_sandbox_request_without_http_call():
     }
 
 
+def test_prepare_create_pix_payment_includes_opaque_external_reference():
+    client = make_client()
+    external_reference = f"agpay_{'f' * 32}"
+
+    request = client.prepare_create_pix_payment(
+        customer_id="cus_external_reference_xxxxxxxx",
+        value=Decimal("50.00"),
+        due_date="2026-07-10",
+        description="Correlação Pix Sandbox Aurea Gold",
+        external_reference=external_reference,
+    )
+
+    assert request.json["externalReference"] == external_reference
+    assert request.real_money is False
+    assert request.http_call_executed is False
+
+
 def test_prepare_get_pix_qr_code_builds_sandbox_request_without_http_call():
     client = make_client()
 

--- a/backend/tests/test_wallet_asaas_payment_user_correlation_contract.py
+++ b/backend/tests/test_wallet_asaas_payment_user_correlation_contract.py
@@ -1,0 +1,193 @@
+import json
+
+import pytest
+
+from app.models.idempotency import IdempotencyKey
+from app.partner.asaas_payment_correlation import (
+    ASAAS_PAYMENT_CORRELATION_KEY_PREFIX,
+    ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX,
+    asaas_payment_correlation_key,
+    build_asaas_payment_user_correlation_record,
+    generate_asaas_payment_external_reference,
+    resolve_asaas_payment_user_correlation_from_payment,
+    validate_asaas_payment_external_reference,
+)
+
+
+class FakeQuery:
+    def __init__(self, db):
+        self.db = db
+        self.key = None
+
+    def filter_by(self, **kwargs):
+        self.key = kwargs.get("key")
+        return self
+
+    def first(self):
+        return self.db.records.get(self.key)
+
+
+class FakeDb:
+    def __init__(self):
+        self.records = {}
+
+    def query(self, model):
+        assert model is IdempotencyKey
+        return FakeQuery(self)
+
+
+def _opaque_reference(character: str = "a") -> str:
+    return (
+        f"{ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX}"
+        f"{character * 32}"
+    )
+
+
+def test_generated_external_reference_is_opaque_and_valid():
+    external_reference = (
+        generate_asaas_payment_external_reference()
+    )
+
+    assert external_reference.startswith(
+        ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX
+    )
+    assert len(external_reference) == (
+        len(ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX) + 32
+    )
+    assert (
+        validate_asaas_payment_external_reference(
+            external_reference
+        )
+        == external_reference
+    )
+
+
+@pytest.mark.parametrize(
+    "external_reference",
+    [
+        "",
+        "321",
+        "user-321-payment",
+        "agpay_short",
+        f"{ASAAS_PAYMENT_EXTERNAL_REFERENCE_PREFIX}{'g' * 32}",
+    ],
+)
+def test_external_reference_rejects_non_opaque_values(
+    external_reference,
+):
+    with pytest.raises(ValueError):
+        validate_asaas_payment_external_reference(
+            external_reference
+        )
+
+
+def test_correlation_record_stores_user_without_raw_reference():
+    external_reference = _opaque_reference("b")
+
+    record = build_asaas_payment_user_correlation_record(
+        user_id=321,
+        external_reference=external_reference,
+    )
+    stored_contract = json.loads(record.response_json)
+
+    assert record.key.startswith(
+        ASAAS_PAYMENT_CORRELATION_KEY_PREFIX
+    )
+    assert external_reference not in record.key
+    assert external_reference not in record.request_hash
+    assert external_reference not in record.response_json
+    assert stored_contract["user_id"] == 321
+    assert (
+        stored_contract["raw_external_reference_stored"]
+        is False
+    )
+    assert stored_contract["real_money_enabled"] is False
+    assert stored_contract["can_credit_balance"] is False
+
+
+def test_payment_payload_resolves_only_pre_registered_user():
+    db = FakeDb()
+    external_reference = _opaque_reference("c")
+    record = build_asaas_payment_user_correlation_record(
+        user_id=321,
+        external_reference=external_reference,
+    )
+    db.records[record.key] = record
+
+    resolved = (
+        resolve_asaas_payment_user_correlation_from_payment(
+            db,
+            payment_payload={
+                "externalReference": external_reference,
+                "status": "RECEIVED",
+            },
+        )
+    )
+
+    assert resolved is not None
+    assert resolved.user_id == 321
+    assert resolved.raw_external_reference_stored is False
+    assert resolved.safe_summary() == {
+        "provider": "asaas",
+        "environment": "sandbox",
+        "user_id_present": True,
+        "correlation_key_present": True,
+        "external_reference_present": True,
+        "raw_external_reference_stored": False,
+        "correlation_status": "resolved",
+    }
+    assert external_reference not in repr(
+        resolved.safe_summary()
+    )
+
+
+def test_unknown_or_missing_reference_does_not_resolve_user():
+    db = FakeDb()
+
+    assert (
+        resolve_asaas_payment_user_correlation_from_payment(
+            db,
+            payment_payload={},
+        )
+        is None
+    )
+    assert (
+        resolve_asaas_payment_user_correlation_from_payment(
+            db,
+            payment_payload={
+                "externalReference": _opaque_reference("d")
+            },
+        )
+        is None
+    )
+    assert (
+        resolve_asaas_payment_user_correlation_from_payment(
+            db,
+            payment_payload={
+                "externalReference": "user-654-payment"
+            },
+        )
+        is None
+    )
+
+
+def test_same_reference_for_another_user_has_detectable_conflict():
+    external_reference = _opaque_reference("e")
+
+    first = build_asaas_payment_user_correlation_record(
+        user_id=321,
+        external_reference=external_reference,
+    )
+    second = build_asaas_payment_user_correlation_record(
+        user_id=654,
+        external_reference=external_reference,
+    )
+
+    assert first.key == second.key
+    assert first.request_hash != second.request_hash
+    assert (
+        first.key
+        == asaas_payment_correlation_key(
+            external_reference
+        )
+    )


### PR DESCRIPTION
## Objetivo

Criar o contrato seguro de correlação entre uma cobrança Asaas Sandbox e o usuário interno da Aurea Gold.

## Implementado

- suporte opcional a `externalReference` na preparação da cobrança PIX
- referência opaca gerada pela Aurea Gold
- rejeição de referências contendo usuário ou valores previsíveis
- armazenamento somente da chave derivada por hash
- vínculo local com `user_id`
- resolução apenas de correlações previamente registradas
- conflito detectável quando a mesma referência é vinculada a outro usuário
- referência bruta não armazenada
- compatibilidade preservada com chamadas existentes

## Validação

- testes específicos e cliente Asaas: 100 passed
- regressão ampliada: 125 passed
- 1 warning conhecido do passlib
- `git diff --check` OK
- pre-commit OK

## Limites

- contrato local de correlação
- ainda não integrado ao receiver `PAYMENT_RECEIVED`
- nenhuma chamada HTTP externa
- nenhuma cobrança real criada
- produção e dinheiro real permanecem desativados