### PR TITLE
test(wallet): integrate Asaas payment received user correlation

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -20,6 +20,9 @@ from app.partner import (
     get_partner_adapter,
 )
 from app.partner.asaas_config import AsaasConfigError, load_asaas_sandbox_config
+from app.partner.asaas_payment_correlation import (
+    resolve_asaas_payment_user_correlation_from_payment,
+)
 from app.services.wallet_partner_service import (
     create_wallet_pix_payment as create_partner_pix_payment,
     get_wallet_balance as get_partner_wallet_balance,
@@ -967,6 +970,77 @@ def _asaas_sandbox_webhook_idempotency_key(event_id: str) -> str:
     return f"asaas-sandbox-webhook:{digest}"
 
 
+def _asaas_sandbox_payment_correlation(
+    db,
+    *,
+    accepted: bool,
+    payment_payload: dict,
+):
+    raw_external_reference = (
+        payment_payload.get("externalReference")
+        or payment_payload.get("external_reference")
+    )
+    external_reference_present = bool(
+        str(raw_external_reference or "").strip()
+    )
+
+    base_summary = {
+        "provider": "asaas",
+        "environment": "sandbox",
+        "user_id_present": False,
+        "correlation_key_present": False,
+        "external_reference_present": external_reference_present,
+        "raw_external_reference_stored": False,
+        "can_credit_balance": False,
+    }
+
+    if not accepted:
+        return {
+            **base_summary,
+            "correlation_status": "not_applicable",
+        }, None
+
+    correlation = (
+        resolve_asaas_payment_user_correlation_from_payment(
+            db,
+            payment_payload=payment_payload,
+        )
+    )
+
+    if correlation is None:
+        return {
+            **base_summary,
+            "correlation_status": (
+                "unresolved"
+                if external_reference_present
+                else "missing"
+            ),
+        }, None
+
+    return {
+        **correlation.safe_summary(),
+        "can_credit_balance": False,
+    }, correlation
+
+
+def _asaas_sandbox_webhook_public_response(
+    stored_response: dict,
+) -> dict:
+    public_response = json.loads(
+        json.dumps(
+            stored_response,
+            ensure_ascii=False,
+            default=str,
+        )
+    )
+
+    audit = public_response.get("audit")
+    if isinstance(audit, dict):
+        audit.pop("correlation_storage", None)
+
+    return public_response
+
+
 @router.post("/api/v1/partners")
 @router.post("/api/v1/partners/")
 @router.post("/api/v1/partners/asaas/webhooks/sandbox")
@@ -1021,7 +1095,10 @@ def handle_asaas_sandbox_webhook_receiver(
             )
 
         if existing.response_json:
-            response = json.loads(existing.response_json)
+            stored_response = json.loads(existing.response_json)
+            response = _asaas_sandbox_webhook_public_response(
+                stored_response
+            )
             response["duplicated"] = True
             response.setdefault("idempotency", {})["replayed"] = True
             response["idempotency"]["state"] = "replayed"
@@ -1063,7 +1140,18 @@ def handle_asaas_sandbox_webhook_receiver(
 
 
     accepted = event_type in _ASAAS_SANDBOX_WEBHOOK_ACCEPTED_EVENTS
-    payment_payload = payload.get("payment") if isinstance(payload.get("payment"), dict) else {}
+    payment_payload = (
+        payload.get("payment")
+        if isinstance(payload.get("payment"), dict)
+        else {}
+    )
+    correlation_summary, payment_correlation = (
+        _asaas_sandbox_payment_correlation(
+            db,
+            accepted=accepted,
+            payment_payload=payment_payload,
+        )
+    )
     now = datetime.now(timezone.utc)
 
     audit_record = {
@@ -1082,6 +1170,7 @@ def handle_asaas_sandbox_webhook_receiver(
         "payment_id_present": bool(payment_payload.get("id")),
         "payment_status": payment_payload.get("status"),
         "billing_type": payment_payload.get("billingType"),
+        "correlation": correlation_summary,
         "received_at": now.isoformat(),
         "storage": {
             "source": "idempotency_keys",
@@ -1119,7 +1208,11 @@ def handle_asaas_sandbox_webhook_receiver(
             "payment_id_present": bool(payment_payload.get("id")),
             "status": payment_payload.get("status"),
             "billing_type": payment_payload.get("billingType"),
+            "external_reference_present": correlation_summary[
+                "external_reference_present"
+            ],
         },
+        "correlation": correlation_summary,
         "wallet": {
             "mode": WALLET_MODE,
             "provider": provider,
@@ -1150,9 +1243,33 @@ def handle_asaas_sandbox_webhook_receiver(
         ],
     }
 
+    stored_response = json.loads(
+        json.dumps(
+            response,
+            ensure_ascii=False,
+            default=str,
+        )
+    )
+
+    if payment_correlation is not None:
+        stored_response.setdefault("audit", {})[
+            "correlation_storage"
+        ] = {
+            "contract": (
+                "asaas_payment_received_user_correlation_v1"
+            ),
+            "user_id": payment_correlation.user_id,
+            "correlation_key": (
+                payment_correlation.correlation_key
+            ),
+            "raw_external_reference_stored": False,
+            "can_credit_balance": False,
+            "real_money_enabled": False,
+        }
+
     record.status_code = 200
     record.response_json = json.dumps(
-        response,
+        stored_response,
         ensure_ascii=False,
         default=str,
     )

--- a/backend/tests/test_asaas_webhook_receiver.py
+++ b/backend/tests/test_asaas_webhook_receiver.py
@@ -11,6 +11,10 @@ from fastapi import HTTPException
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.api.v1.routes import wallet as wallet_routes
+from app.partner.asaas_payment_correlation import (
+    asaas_payment_correlation_key,
+    build_asaas_payment_user_correlation_record,
+)
 
 
 class FakeQuery:
@@ -404,3 +408,169 @@ def test_asaas_sandbox_webhook_commit_failure_rolls_back_and_returns_503():
     assert "secret-token" not in rendered
     assert "evt_test_unique_001" not in rendered
     assert "pay_real_sandbox_must_not_leak" not in rendered
+
+def test_payment_received_resolves_pre_registered_user_without_public_leak():
+    db = FakeDb()
+    external_reference = f"agpay_{'a' * 32}"
+
+    correlation_record = (
+        build_asaas_payment_user_correlation_record(
+            user_id=321,
+            external_reference=external_reference,
+        )
+    )
+    db.records[correlation_record.key] = correlation_record
+
+    payload = _valid_payload()
+    payload["id"] = "evt_correlated_payment_received_001"
+    payload["payment"]["externalReference"] = external_reference
+
+    response = (
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+    )
+
+    encoded = json.dumps(
+        response,
+        ensure_ascii=False,
+        default=str,
+    )
+
+    assert response["event"]["accepted"] is True
+    assert response["payment"]["external_reference_present"] is True
+    assert (
+        response["correlation"]["correlation_status"]
+        == "resolved"
+    )
+    assert response["correlation"]["user_id_present"] is True
+    assert (
+        response["correlation"]["correlation_key_present"]
+        is True
+    )
+    assert (
+        response["correlation"]["raw_external_reference_stored"]
+        is False
+    )
+    assert response["correlation"]["can_credit_balance"] is False
+    assert "user_id" not in response["correlation"]
+    assert "correlation_key" not in response["correlation"]
+    assert "correlation_storage" not in response["audit"]
+    assert external_reference not in encoded
+
+    event_key = (
+        wallet_routes._asaas_sandbox_webhook_idempotency_key(
+            payload["id"]
+        )
+    )
+    stored_response = json.loads(
+        db.records[event_key].response_json
+    )
+    correlation_storage = stored_response["audit"][
+        "correlation_storage"
+    ]
+
+    assert correlation_storage["user_id"] == 321
+    assert correlation_storage["correlation_key"] == (
+        asaas_payment_correlation_key(external_reference)
+    )
+    assert (
+        correlation_storage["raw_external_reference_stored"]
+        is False
+    )
+    assert correlation_storage["can_credit_balance"] is False
+    assert external_reference not in db.records[event_key].response_json
+
+
+def test_payment_received_with_unknown_reference_remains_unresolved():
+    db = FakeDb()
+    external_reference = f"agpay_{'b' * 32}"
+
+    payload = _valid_payload()
+    payload["id"] = "evt_unknown_correlation_001"
+    payload["payment"]["externalReference"] = external_reference
+
+    response = (
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+    )
+
+    assert (
+        response["correlation"]["correlation_status"]
+        == "unresolved"
+    )
+    assert response["correlation"]["user_id_present"] is False
+    assert (
+        response["correlation"]["correlation_key_present"]
+        is False
+    )
+    assert response["can_credit_balance"] is False
+
+    event_key = (
+        wallet_routes._asaas_sandbox_webhook_idempotency_key(
+            payload["id"]
+        )
+    )
+    stored_response = json.loads(
+        db.records[event_key].response_json
+    )
+
+    assert (
+        "correlation_storage"
+        not in stored_response["audit"]
+    )
+    assert external_reference not in db.records[event_key].response_json
+
+
+def test_correlated_payment_received_replay_remains_sanitized():
+    db = FakeDb()
+    external_reference = f"agpay_{'c' * 32}"
+
+    correlation_record = (
+        build_asaas_payment_user_correlation_record(
+            user_id=654,
+            external_reference=external_reference,
+        )
+    )
+    db.records[correlation_record.key] = correlation_record
+
+    payload = _valid_payload()
+    payload["id"] = "evt_correlated_replay_001"
+    payload["payment"]["externalReference"] = external_reference
+
+    wallet_routes.handle_asaas_sandbox_webhook_receiver(
+        payload=payload,
+        db=db,
+        asaas_access_token="secret-token",
+    )
+    replay = (
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+    )
+
+    encoded = json.dumps(
+        replay,
+        ensure_ascii=False,
+        default=str,
+    )
+
+    assert replay["duplicated"] is True
+    assert replay["idempotency"]["replayed"] is True
+    assert (
+        replay["correlation"]["correlation_status"]
+        == "resolved"
+    )
+    assert replay["correlation"]["user_id_present"] is True
+    assert "correlation_storage" not in replay["audit"]
+    assert "user_id" not in replay["correlation"]
+    assert "correlation_key" not in replay["correlation"]
+    assert external_reference not in encoded
+    assert replay["can_credit_balance"] is False


### PR DESCRIPTION
## Objetivo

Integrar o contrato seguro de correlação ao receiver Asaas Sandbox para eventos `PAYMENT_RECEIVED`.

## Implementado

- leitura sanitizada de `payment.externalReference`
- resolução somente de correlação previamente registrada
- vínculo interno entre evento e `user_id`
- referência ausente marcada como `missing`
- referência desconhecida ou inválida marcada como `unresolved`
- eventos não aplicáveis não tentam correlacionar usuário
- armazenamento interno apenas de `user_id` e chave derivada por hash
- remoção dos dados internos da resposta pública
- replay idempotente permanece sanitizado
- nenhuma referência bruta armazenada ou exposta
- nenhuma chave interna ou `user_id` expostos ao webhook
- nenhuma autorização para crédito de saldo

## Validação

- testes específicos: 22 passed
- regressão ampliada: 128 passed
- 1 warning conhecido do passlib
- `git diff --check` OK
- pre-commit OK

## Limites

- ambiente Asaas Sandbox
- nenhuma chamada HTTP externa nesta entrega
- nenhuma cobrança criada
- nenhum saldo creditado
- nenhum comprovante financeiro real
- produção e dinheiro real permanecem desativados