### PR TITLE
test(wallet): project correlated Asaas payments to statement

### DIFF
--- a/backend/app/api/v1/routes/wallet.py
+++ b/backend/app/api/v1/routes/wallet.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from datetime import datetime, timezone
 import hashlib
 import hmac
@@ -218,6 +218,38 @@ def _statement_item_payload(item, *, source: str, real_money_enabled: bool) -> d
     }
 
 
+def _asaas_sandbox_positive_amount(
+    raw_value,
+) -> Decimal | None:
+    if raw_value is None or isinstance(raw_value, bool):
+        return None
+
+    try:
+        amount = Decimal(str(raw_value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+    if not amount.is_finite() or amount <= Decimal("0.00"):
+        return None
+
+    return amount
+
+
+def _asaas_sandbox_statement_reference(
+    correlation_key: str,
+) -> str | None:
+    normalized = str(correlation_key or "").strip()
+
+    if not normalized.startswith("asaas-payment-correlation:"):
+        return None
+
+    digest = hashlib.sha256(
+        normalized.encode("utf-8")
+    ).hexdigest()
+
+    return f"asaas-sandbox-payment-{digest[:24]}"
+
+
 def _sandbox_statement_items_from_webhooks(
     db: Session,
     *,
@@ -297,6 +329,117 @@ def _sandbox_statement_items_from_webhooks(
 
 
 
+def _asaas_sandbox_statement_items_from_webhooks(
+    db: Session,
+    *,
+    user_id: int,
+    limit: int,
+) -> list[StatementItem]:
+    safe_limit = max(1, min(int(limit or 50), 100))
+    rows = (
+        db.query(IdempotencyKey)
+        .filter(
+            IdempotencyKey.key.like(
+                "asaas-sandbox-webhook:%"
+            )
+        )
+        .order_by(IdempotencyKey.created_at.desc())
+        .limit(min(safe_limit * 4, 400))
+        .all()
+    )
+
+    items: list[StatementItem] = []
+    seen_references: set[str] = set()
+
+    for row in rows:
+        row_key = str(getattr(row, "key", "") or "")
+        if not row_key.startswith("asaas-sandbox-webhook:"):
+            continue
+
+        raw_response = getattr(row, "response_json", None)
+        if not raw_response:
+            continue
+
+        try:
+            response = json.loads(raw_response)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+
+        event = response.get("event") or {}
+        audit = response.get("audit") or {}
+        correlation_storage = (
+            audit.get("correlation_storage") or {}
+        )
+
+        if (
+            event.get("event_type") != "PAYMENT_RECEIVED"
+            or event.get("accepted") is not True
+        ):
+            continue
+
+        if (
+            correlation_storage.get("contract")
+            != "asaas_payment_received_user_correlation_v1"
+        ):
+            continue
+
+        if correlation_storage.get("user_id") != user_id:
+            continue
+
+        if (
+            correlation_storage.get("real_money_enabled")
+            is not False
+            or correlation_storage.get("can_credit_balance")
+            is not False
+        ):
+            continue
+
+        amount = _asaas_sandbox_positive_amount(
+            correlation_storage.get("amount")
+        )
+        if amount is None:
+            continue
+
+        provider_reference = (
+            _asaas_sandbox_statement_reference(
+                correlation_storage.get("correlation_key")
+            )
+        )
+        if (
+            provider_reference is None
+            or provider_reference in seen_references
+        ):
+            continue
+
+        seen_references.add(provider_reference)
+        items.append(
+            StatementItem(
+                provider_reference=provider_reference,
+                amount=amount,
+                direction="credit",
+                status="confirmed",
+                description="PIX Asaas Sandbox recebido",
+                created_at=(
+                    event.get("received_at")
+                    or audit.get("received_at")
+                ),
+                raw={
+                    "sandbox": True,
+                    "real_money": False,
+                    "source": (
+                        "asaas_sandbox_payment_received"
+                    ),
+                },
+            )
+        )
+
+        if len(items) >= safe_limit:
+            break
+
+    return items
+
+
+
 @router.get("/api/v1/wallet/structured-statement")
 def get_wallet_structured_statement(
     limit: int = 50,
@@ -333,6 +476,13 @@ def get_wallet_structured_statement(
         if provider == "sandbox":
             statement.extend(
                 _sandbox_statement_items_from_webhooks(
+                    db,
+                    user_id=current_user.id,
+                    limit=safe_limit,
+                )
+            )
+            statement.extend(
+                _asaas_sandbox_statement_items_from_webhooks(
                     db,
                     user_id=current_user.id,
                     limit=safe_limit,
@@ -1152,6 +1302,9 @@ def handle_asaas_sandbox_webhook_receiver(
             payment_payload=payment_payload,
         )
     )
+    payment_amount = _asaas_sandbox_positive_amount(
+        payment_payload.get("value")
+    )
     now = datetime.now(timezone.utc)
 
     audit_record = {
@@ -1252,9 +1405,7 @@ def handle_asaas_sandbox_webhook_receiver(
     )
 
     if payment_correlation is not None:
-        stored_response.setdefault("audit", {})[
-            "correlation_storage"
-        ] = {
+        correlation_storage = {
             "contract": (
                 "asaas_payment_received_user_correlation_v1"
             ),
@@ -1262,10 +1413,21 @@ def handle_asaas_sandbox_webhook_receiver(
             "correlation_key": (
                 payment_correlation.correlation_key
             ),
+            "amount_present": payment_amount is not None,
+            "currency": "BRL",
             "raw_external_reference_stored": False,
             "can_credit_balance": False,
             "real_money_enabled": False,
         }
+
+        if payment_amount is not None:
+            correlation_storage["amount"] = (
+                _decimal_as_money(payment_amount)
+            )
+
+        stored_response.setdefault("audit", {})[
+            "correlation_storage"
+        ] = correlation_storage
 
     record.status_code = 200
     record.response_json = json.dumps(

--- a/backend/tests/test_wallet_sandbox_end_to_end_statement.py
+++ b/backend/tests/test_wallet_sandbox_end_to_end_statement.py
@@ -10,6 +10,9 @@ from sqlalchemy.exc import IntegrityError
 
 from app.api.v1.routes import wallet as wallet_routes
 from app.partner import PixPaymentRequest, SandboxPartnerAdapter
+from app.partner.asaas_payment_correlation import (
+    build_asaas_payment_user_correlation_record,
+)
 
 
 class FakeQuery:
@@ -226,3 +229,183 @@ def test_sandbox_statement_does_not_mix_events_between_users(monkeypatch):
     assert second_statement["statement"]["count"] == 0
     assert second_statement["statement"]["items"] == []
     assert second_statement["wallet"]["real_money_enabled"] is False
+
+def test_asaas_correlated_payment_received_projects_once_to_statement(
+    monkeypatch,
+):
+    _configure_sandbox(monkeypatch)
+    monkeypatch.setattr(
+        wallet_routes,
+        "load_asaas_sandbox_config",
+        lambda: SimpleNamespace(
+            webhook_token="secret-token",
+            env="sandbox",
+        ),
+    )
+
+    db = FakeDb()
+    owner = SimpleNamespace(id=321)
+    other_user = SimpleNamespace(id=654)
+    external_reference = f"agpay_{'a' * 32}"
+
+    correlation_record = (
+        build_asaas_payment_user_correlation_record(
+            user_id=owner.id,
+            external_reference=external_reference,
+        )
+    )
+    db.records[correlation_record.key] = correlation_record
+
+    payload = {
+        "id": "evt_statement_projection_001",
+        "event": "PAYMENT_RECEIVED",
+        "payment": {
+            "id": "pay_statement_projection_must_not_leak",
+            "status": "RECEIVED",
+            "billingType": "PIX",
+            "externalReference": external_reference,
+            "value": 47.30,
+        },
+    }
+
+    first = (
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+    )
+    replay = (
+        wallet_routes.handle_asaas_sandbox_webhook_receiver(
+            payload=payload,
+            db=db,
+            asaas_access_token="secret-token",
+        )
+    )
+
+    owner_statement = (
+        wallet_routes.get_wallet_structured_statement(
+            limit=50,
+            current_user=owner,
+            db=db,
+        )
+    )
+    other_statement = (
+        wallet_routes.get_wallet_structured_statement(
+            limit=50,
+            current_user=other_user,
+            db=db,
+        )
+    )
+
+    assert first["duplicated"] is False
+    assert first["can_credit_balance"] is False
+    assert replay["duplicated"] is True
+    assert replay["idempotency"]["replayed"] is True
+
+    assert owner_statement["statement"]["count"] == 1
+    assert other_statement["statement"]["count"] == 0
+    assert (
+        owner_statement["wallet"]["real_money_enabled"]
+        is False
+    )
+
+    item = owner_statement["statement"]["items"][0]
+
+    assert item["provider_reference"].startswith(
+        "asaas-sandbox-payment-"
+    )
+    assert item["direction"] == "credit"
+    assert item["amount"] == "47.30"
+    assert item["status"] == "confirmed"
+    assert (
+        item["description"]
+        == "PIX Asaas Sandbox recebido"
+    )
+    assert item["source"] == "sandbox"
+    assert item["real_money_enabled"] is False
+
+    rendered = json.dumps(
+        owner_statement,
+        ensure_ascii=False,
+        default=str,
+    )
+
+    assert external_reference not in rendered
+    assert (
+        "pay_statement_projection_must_not_leak"
+        not in rendered
+    )
+    assert "correlation_key" not in rendered
+    assert "user_id" not in item
+
+
+def test_asaas_unresolved_or_amountless_event_is_not_projected(
+    monkeypatch,
+):
+    _configure_sandbox(monkeypatch)
+    monkeypatch.setattr(
+        wallet_routes,
+        "load_asaas_sandbox_config",
+        lambda: SimpleNamespace(
+            webhook_token="secret-token",
+            env="sandbox",
+        ),
+    )
+
+    db = FakeDb()
+    user = SimpleNamespace(id=321)
+
+    unresolved_payload = {
+        "id": "evt_statement_unresolved_001",
+        "event": "PAYMENT_RECEIVED",
+        "payment": {
+            "id": "pay_unresolved_must_not_leak",
+            "status": "RECEIVED",
+            "billingType": "PIX",
+            "externalReference": f"agpay_{'b' * 32}",
+            "value": 25.00,
+        },
+    }
+
+    wallet_routes.handle_asaas_sandbox_webhook_receiver(
+        payload=unresolved_payload,
+        db=db,
+        asaas_access_token="secret-token",
+    )
+
+    correlated_reference = f"agpay_{'c' * 32}"
+    correlation_record = (
+        build_asaas_payment_user_correlation_record(
+            user_id=user.id,
+            external_reference=correlated_reference,
+        )
+    )
+    db.records[correlation_record.key] = correlation_record
+
+    amountless_payload = {
+        "id": "evt_statement_amountless_001",
+        "event": "PAYMENT_RECEIVED",
+        "payment": {
+            "id": "pay_amountless_must_not_leak",
+            "status": "RECEIVED",
+            "billingType": "PIX",
+            "externalReference": correlated_reference,
+        },
+    }
+
+    wallet_routes.handle_asaas_sandbox_webhook_receiver(
+        payload=amountless_payload,
+        db=db,
+        asaas_access_token="secret-token",
+    )
+
+    statement = wallet_routes.get_wallet_structured_statement(
+        limit=50,
+        current_user=user,
+        db=db,
+    )
+
+    assert statement["statement"]["count"] == 0
+    assert statement["statement"]["items"] == []
+    assert statement["wallet"]["real_money_enabled"] is False


### PR DESCRIPTION
## Objetivo

Projetar no extrato Sandbox o evento Asaas `PAYMENT_RECEIVED` que tenha correlação segura com um usuário interno.

## Implementado

- leitura dos registros `asaas-sandbox-webhook:*`
- projeção somente de eventos `PAYMENT_RECEIVED` aceitos
- exigência de correlação previamente registrada
- isolamento rigoroso por `user_id`
- valor monetário sanitizado e obrigatoriamente positivo
- deduplicação por referência derivada
- replay do webhook não duplica o lançamento
- evento desconhecido, não correlacionado ou sem valor não entra no extrato
- referência Asaas bruta, payment ID e chave interna não aparecem no extrato
- lançamento permanece marcado como Sandbox
- nenhum crédito de saldo real

## Validação

- testes específicos: 26 passed
- regressão ampliada: 130 passed
- 1 warning conhecido do passlib
- `git diff --check` OK
- pre-commit OK

## Limites

- projeção somente no extrato estruturado Sandbox
- não altera saldo contábil ou financeiro real
- nenhuma chamada HTTP externa nesta entrega
- nenhum comprovante financeiro real
- produção e dinheiro real permanecem desativados