### PR TITLE
test(wallet): add correlated Asaas pix payment preparation

### DIFF
--- a/backend/app/services/asaas_correlated_pix_payment_service.py
+++ b/backend/app/services/asaas_correlated_pix_payment_service.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from app.models.idempotency import IdempotencyKey
+from app.partner.asaas_client import (
+    AsaasPreparedRequest,
+    AsaasSandboxClient,
+)
+from app.partner.asaas_payment_correlation import (
+    build_asaas_payment_user_correlation_record,
+    generate_asaas_payment_external_reference,
+    validate_asaas_payment_external_reference,
+)
+
+
+ASAAS_CORRELATED_PIX_PAYMENT_PREPARATION_CONTRACT = (
+    "asaas_correlated_pix_payment_preparation_v1"
+)
+
+
+class AsaasCorrelatedPixPaymentConflictError(RuntimeError):
+    pass
+
+
+class AsaasCorrelatedPixPaymentStorageError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AsaasCorrelatedPixPaymentPreparation:
+    user_id: int = field(repr=False)
+    external_reference: str = field(repr=False)
+    correlation_key: str = field(repr=False)
+    prepared_request: AsaasPreparedRequest = field(repr=False)
+    correlation_replayed: bool = False
+    sandbox_only: bool = True
+    real_money: bool = False
+    http_call_executed: bool = False
+    can_send_http: bool = False
+
+    def safe_summary(self) -> dict[str, Any]:
+        return {
+            "operation": (
+                "prepare_asaas_correlated_pix_payment"
+            ),
+            "provider": "asaas",
+            "environment": "sandbox",
+            "user_id_present": True,
+            "external_reference_present": True,
+            "correlation_key_present": True,
+            "raw_external_reference_stored": False,
+            "correlation_replayed": (
+                self.correlation_replayed
+            ),
+            "prepared_request": {
+                "method": self.prepared_request.method,
+                "operation": (
+                    self.prepared_request.operation
+                ),
+                "external_reference_present": True,
+                "headers_configured": (
+                    self.prepared_request.headers_configured
+                ),
+                "real_money": (
+                    self.prepared_request.real_money
+                ),
+                "http_call_executed": (
+                    self.prepared_request.http_call_executed
+                ),
+            },
+            "sandbox_only": self.sandbox_only,
+            "real_money": self.real_money,
+            "http_call_executed": (
+                self.http_call_executed
+            ),
+            "can_send_http": self.can_send_http,
+        }
+
+
+def _required_text(value, *, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} é obrigatório.")
+    return normalized
+
+
+def _positive_amount(value) -> Decimal:
+    if value is None or isinstance(value, bool):
+        raise ValueError(
+            "value deve ser maior que zero."
+        )
+
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(
+            "value deve ser um valor monetário válido."
+        ) from exc
+
+    if not amount.is_finite() or amount <= Decimal("0.00"):
+        raise ValueError(
+            "value deve ser maior que zero."
+        )
+
+    return amount
+
+
+def _preparation_hash(
+    *,
+    user_id: int,
+    correlation_key: str,
+    customer_id: str,
+    value: Decimal,
+    due_date: str,
+    description: str,
+) -> str:
+    contract = {
+        "contract": (
+            ASAAS_CORRELATED_PIX_PAYMENT_PREPARATION_CONTRACT
+        ),
+        "user_id": user_id,
+        "correlation_key": correlation_key,
+        "customer_id": customer_id,
+        "value": format(value, "f"),
+        "due_date": due_date,
+        "description": description,
+    }
+    encoded = json.dumps(
+        contract,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stored_preparation_contract(
+    *,
+    correlation_record: IdempotencyKey,
+    preparation_hash: str,
+) -> str:
+    stored_contract = json.loads(
+        correlation_record.response_json or "{}"
+    )
+    stored_contract.update(
+        {
+            "preparation_contract": (
+                ASAAS_CORRELATED_PIX_PAYMENT_PREPARATION_CONTRACT
+            ),
+            "prepared_request_hash": preparation_hash,
+            "payment_operation": "create_pix_payment",
+            "billing_type": "PIX",
+            "prepared_request_present": True,
+            "external_reference_present": True,
+            "raw_external_reference_stored": False,
+            "http_call_executed": False,
+            "can_send_http": False,
+            "real_money_enabled": False,
+        }
+    )
+    return json.dumps(
+        stored_contract,
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _existing_preparation_matches(
+    existing: IdempotencyKey,
+    *,
+    preparation_hash: str,
+) -> bool:
+    if (
+        getattr(existing, "request_hash", None)
+        != preparation_hash
+    ):
+        return False
+
+    try:
+        stored_contract = json.loads(
+            existing.response_json or "{}"
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+    return (
+        stored_contract.get("preparation_contract")
+        == ASAAS_CORRELATED_PIX_PAYMENT_PREPARATION_CONTRACT
+        and stored_contract.get("prepared_request_hash")
+        == preparation_hash
+        and stored_contract.get("http_call_executed")
+        is False
+        and stored_contract.get("real_money_enabled")
+        is False
+    )
+
+
+def prepare_asaas_correlated_pix_payment(
+    db,
+    *,
+    client: AsaasSandboxClient,
+    user_id: int,
+    customer_id: str,
+    value: Decimal,
+    due_date: str,
+    description: str,
+    external_reference: str | None = None,
+) -> AsaasCorrelatedPixPaymentPreparation:
+    normalized_customer_id = _required_text(
+        customer_id,
+        field_name="customer_id",
+    )
+    normalized_due_date = _required_text(
+        due_date,
+        field_name="due_date",
+    )
+    normalized_description = _required_text(
+        description,
+        field_name="description",
+    )
+    normalized_value = _positive_amount(value)
+
+    generated_reference = (
+        external_reference
+        if external_reference is not None
+        else generate_asaas_payment_external_reference()
+    )
+    normalized_external_reference = (
+        validate_asaas_payment_external_reference(
+            generated_reference
+        )
+    )
+
+    correlation_record = (
+        build_asaas_payment_user_correlation_record(
+            user_id=user_id,
+            external_reference=(
+                normalized_external_reference
+            ),
+        )
+    )
+    stored_correlation = json.loads(
+        correlation_record.response_json or "{}"
+    )
+    normalized_user_id = int(
+        stored_correlation["user_id"]
+    )
+
+    prepared_request = client.prepare_create_pix_payment(
+        customer_id=normalized_customer_id,
+        value=normalized_value,
+        due_date=normalized_due_date,
+        description=normalized_description,
+        external_reference=(
+            normalized_external_reference
+        ),
+    )
+
+    preparation_hash = _preparation_hash(
+        user_id=normalized_user_id,
+        correlation_key=correlation_record.key,
+        customer_id=normalized_customer_id,
+        value=normalized_value,
+        due_date=normalized_due_date,
+        description=normalized_description,
+    )
+
+    correlation_record.request_hash = preparation_hash
+    correlation_record.response_json = (
+        _stored_preparation_contract(
+            correlation_record=correlation_record,
+            preparation_hash=preparation_hash,
+        )
+    )
+
+    replayed = False
+
+    try:
+        db.add(correlation_record)
+        db.flush()
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(IdempotencyKey)
+            .filter_by(key=correlation_record.key)
+            .first()
+        )
+
+        if not existing or not _existing_preparation_matches(
+            existing,
+            preparation_hash=preparation_hash,
+        ):
+            raise AsaasCorrelatedPixPaymentConflictError(
+                "Referência de correlação já utilizada "
+                "por outra preparação."
+            ) from None
+
+        replayed = True
+    except SQLAlchemyError:
+        db.rollback()
+        raise AsaasCorrelatedPixPaymentStorageError(
+            "Não foi possível registrar a correlação "
+            "da cobrança Asaas Sandbox."
+        ) from None
+
+    return AsaasCorrelatedPixPaymentPreparation(
+        user_id=normalized_user_id,
+        external_reference=(
+            normalized_external_reference
+        ),
+        correlation_key=correlation_record.key,
+        prepared_request=prepared_request,
+        correlation_replayed=replayed,
+    )

--- a/backend/tests/test_wallet_asaas_correlated_pix_payment_preparation.py
+++ b/backend/tests/test_wallet_asaas_correlated_pix_payment_preparation.py
@@ -1,0 +1,301 @@
+import json
+import os
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+
+from app.models.idempotency import IdempotencyKey
+from app.partner.asaas_client import AsaasSandboxClient
+from app.partner.asaas_config import (
+    ASAAS_SANDBOX_BASE_URL,
+    AsaasSandboxConfig,
+)
+from app.services.asaas_correlated_pix_payment_service import (
+    AsaasCorrelatedPixPaymentConflictError,
+    AsaasCorrelatedPixPaymentStorageError,
+    prepare_asaas_correlated_pix_payment,
+)
+
+
+TEST_CONFIG = AsaasSandboxConfig(
+    env="sandbox",
+    base_url=ASAAS_SANDBOX_BASE_URL,
+    api_key="sandbox-api-key-for-test-only",
+    webhook_token="sandbox-webhook-token-for-test-only",
+    real_money_enabled=False,
+    wallet_mode="partner",
+    wallet_partner_provider="asaas",
+)
+
+
+class FakeQuery:
+    def __init__(self, db):
+        self.db = db
+        self.key = None
+
+    def filter_by(self, **kwargs):
+        self.key = kwargs.get("key")
+        return self
+
+    def first(self):
+        return self.db.records.get(self.key)
+
+
+class FakeDb:
+    def __init__(self, *, fail_commit=False):
+        self.records = {}
+        self.pending = None
+        self.inserted_keys = []
+        self.committed = False
+        self.rolled_back = False
+        self.fail_commit = fail_commit
+
+    def add(self, record):
+        self.pending = record
+
+    def flush(self):
+        if self.pending.key in self.records:
+            raise IntegrityError(
+                "duplicate",
+                {},
+                Exception("duplicate"),
+            )
+
+        key = self.pending.key
+        self.records[key] = self.pending
+        self.inserted_keys.append(key)
+        self.pending = None
+
+    def commit(self):
+        if self.fail_commit:
+            raise SQLAlchemyError(
+                "database unavailable with secret value"
+            )
+
+        self.committed = True
+        self.inserted_keys.clear()
+
+    def rollback(self):
+        self.rolled_back = True
+        self.pending = None
+
+        for key in self.inserted_keys:
+            self.records.pop(key, None)
+
+        self.inserted_keys.clear()
+
+    def query(self, model):
+        assert model is IdempotencyKey
+        return FakeQuery(self)
+
+
+def _client() -> AsaasSandboxClient:
+    return AsaasSandboxClient(config=TEST_CONFIG)
+
+
+def _external_reference(character: str) -> str:
+    return f"agpay_{character * 32}"
+
+
+def test_prepares_correlated_pix_payment_and_commits_before_http():
+    db = FakeDb()
+    external_reference = _external_reference("a")
+
+    result = prepare_asaas_correlated_pix_payment(
+        db,
+        client=_client(),
+        user_id=321,
+        customer_id="cus_correlated_test",
+        value=Decimal("49.90"),
+        due_date="2026-07-20",
+        description="Cobrança correlacionada Sandbox",
+        external_reference=external_reference,
+    )
+
+    request = result.prepared_request
+    stored_record = db.records[result.correlation_key]
+    stored_contract = json.loads(
+        stored_record.response_json
+    )
+    safe_summary = result.safe_summary()
+    rendered_summary = json.dumps(
+        safe_summary,
+        ensure_ascii=False,
+        default=str,
+    )
+
+    assert db.committed is True
+    assert result.correlation_replayed is False
+    assert request.method == "POST"
+    assert request.operation == "create_pix_payment"
+    assert request.json["externalReference"] == (
+        external_reference
+    )
+    assert request.json["value"] == 49.9
+    assert request.http_call_executed is False
+    assert request.real_money is False
+
+    assert stored_contract["user_id"] == 321
+    assert (
+        stored_contract["preparation_contract"]
+        == "asaas_correlated_pix_payment_preparation_v1"
+    )
+    assert stored_contract["http_call_executed"] is False
+    assert stored_contract["can_send_http"] is False
+    assert stored_contract["real_money_enabled"] is False
+
+    assert external_reference not in stored_record.response_json
+    assert "cus_correlated_test" not in stored_record.response_json
+    assert external_reference not in rendered_summary
+    assert "cus_correlated_test" not in rendered_summary
+    assert external_reference not in repr(result)
+    assert "sandbox-api-key-for-test-only" not in rendered_summary
+    assert "sandbox-webhook-token-for-test-only" not in rendered_summary
+
+
+def test_generated_reference_is_sent_and_not_stored_raw():
+    db = FakeDb()
+
+    result = prepare_asaas_correlated_pix_payment(
+        db,
+        client=_client(),
+        user_id=654,
+        customer_id="cus_generated_reference",
+        value=Decimal("10.00"),
+        due_date="2026-07-21",
+        description="Referência gerada",
+    )
+
+    external_reference = result.external_reference
+    stored_record = db.records[result.correlation_key]
+
+    assert external_reference.startswith("agpay_")
+    assert len(external_reference) == len("agpay_") + 32
+    assert (
+        result.prepared_request.json[
+            "externalReference"
+        ]
+        == external_reference
+    )
+    assert external_reference not in stored_record.response_json
+    assert external_reference not in repr(result)
+
+
+def test_same_preparation_is_idempotent():
+    db = FakeDb()
+    external_reference = _external_reference("b")
+    kwargs = {
+        "client": _client(),
+        "user_id": 321,
+        "customer_id": "cus_idempotent",
+        "value": Decimal("25.00"),
+        "due_date": "2026-07-22",
+        "description": "Preparação idempotente",
+        "external_reference": external_reference,
+    }
+
+    first = prepare_asaas_correlated_pix_payment(
+        db,
+        **kwargs,
+    )
+    second = prepare_asaas_correlated_pix_payment(
+        db,
+        **kwargs,
+    )
+
+    assert first.correlation_replayed is False
+    assert second.correlation_replayed is True
+    assert first.correlation_key == second.correlation_key
+    assert len(db.records) == 1
+    assert second.prepared_request.http_call_executed is False
+
+
+def test_reused_reference_with_different_payment_conflicts():
+    db = FakeDb()
+    external_reference = _external_reference("c")
+
+    prepare_asaas_correlated_pix_payment(
+        db,
+        client=_client(),
+        user_id=321,
+        customer_id="cus_conflict",
+        value=Decimal("30.00"),
+        due_date="2026-07-23",
+        description="Primeira preparação",
+        external_reference=external_reference,
+    )
+
+    with pytest.raises(
+        AsaasCorrelatedPixPaymentConflictError
+    ):
+        prepare_asaas_correlated_pix_payment(
+            db,
+            client=_client(),
+            user_id=321,
+            customer_id="cus_conflict",
+            value=Decimal("31.00"),
+            due_date="2026-07-23",
+            description="Preparação alterada",
+            external_reference=external_reference,
+        )
+
+    assert len(db.records) == 1
+
+
+@pytest.mark.parametrize(
+    "user_id,value,external_reference",
+    [
+        (0, Decimal("10.00"), _external_reference("d")),
+        (321, Decimal("0.00"), _external_reference("e")),
+        (321, Decimal("10.00"), "user-321-payment"),
+    ],
+)
+def test_invalid_preparation_does_not_register_correlation(
+    user_id,
+    value,
+    external_reference,
+):
+    db = FakeDb()
+
+    with pytest.raises(ValueError):
+        prepare_asaas_correlated_pix_payment(
+            db,
+            client=_client(),
+            user_id=user_id,
+            customer_id="cus_invalid",
+            value=value,
+            due_date="2026-07-24",
+            description="Preparação inválida",
+            external_reference=external_reference,
+        )
+
+    assert db.records == {}
+    assert db.committed is False
+
+
+def test_storage_failure_rolls_back_without_exposing_error():
+    db = FakeDb(fail_commit=True)
+    external_reference = _external_reference("f")
+
+    with pytest.raises(
+        AsaasCorrelatedPixPaymentStorageError
+    ) as exc:
+        prepare_asaas_correlated_pix_payment(
+            db,
+            client=_client(),
+            user_id=321,
+            customer_id="cus_storage_failure",
+            value=Decimal("15.00"),
+            due_date="2026-07-25",
+            description="Falha controlada",
+            external_reference=external_reference,
+        )
+
+    assert db.rolled_back is True
+    assert db.records == {}
+    assert external_reference not in str(exc.value)
+    assert "secret value" not in str(exc.value)


### PR DESCRIPTION
## Objetivo

Preparar com segurança uma cobrança PIX Asaas Sandbox já vinculada ao usuário interno antes de qualquer chamada HTTP.

## Implementado

- serviço transacional separado do cliente HTTP
- geração automática de referência opaca
- validação de referência fornecida manualmente
- registro da correlação antes da requisição preparada
- inclusão da referência em `externalReference`
- persistência somente de chave derivada e contrato sanitizado
- preparação idempotente para a mesma cobrança
- conflito quando a referência é reutilizada com dados diferentes
- rollback sanitizado em falha de persistência
- nenhuma exposição de cliente Asaas, referência bruta ou segredo
- requisição permanece preparada e não executada

## Validação

- testes específicos: 108 passed
- regressão ampliada: 138 passed
- 1 warning conhecido do passlib
- `git diff --check` OK
- pre-commit OK

## Limites

- serviço local sem endpoint público
- nenhuma chamada HTTP externa
- nenhuma cobrança criada no Asaas
- nenhuma movimentação financeira
- produção e dinheiro real permanecem desativados